### PR TITLE
decouple FileService from MemoryStream

### DIFF
--- a/src/PingenApiNet/Interfaces/Connectors/IFilesService.cs
+++ b/src/PingenApiNet/Interfaces/Connectors/IFilesService.cs
@@ -46,8 +46,8 @@ public interface IFilesService
     /// Upload a file to URL received in result from <see cref="GetPath"/>
     /// </summary>
     /// <param name="fileUploadData">Result from <see cref="GetPath"/></param>
-    /// <param name="data">Binary file to upload as memory stream</param>
+    /// <param name="data">Binary file to upload as stream</param>
     /// <param name="cancellationToken">Optional, A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
     /// <returns></returns>
-    public Task<bool> UploadFile(FileUploadData fileUploadData, MemoryStream data, [Optional] CancellationToken cancellationToken);
+    public Task<bool> UploadFile(FileUploadData fileUploadData, Stream data, [Optional] CancellationToken cancellationToken);
 }

--- a/src/PingenApiNet/Services/Connectors/FilesService.cs
+++ b/src/PingenApiNet/Services/Connectors/FilesService.cs
@@ -52,9 +52,9 @@ public sealed class FilesService : ConnectorService, IFilesService
     }
 
     /// <inheritdoc />
-    public async Task<bool> UploadFile(FileUploadData fileUploadData, MemoryStream data, [Optional] CancellationToken cancellationToken)
+    public async Task<bool> UploadFile(FileUploadData fileUploadData, Stream data, [Optional] CancellationToken cancellationToken)
     {
         using var httpClient = new HttpClient();
-        return (await httpClient.PutAsync(fileUploadData.Attributes.Url, new ByteArrayContent(data.ToArray()), cancellationToken)).IsSuccessStatusCode;
+        return (await httpClient.PutAsync(fileUploadData.Attributes.Url, new StreamContent(data), cancellationToken)).IsSuccessStatusCode;
     }
 }


### PR DESCRIPTION
Maybe I missed something but here it is quite easy to decouple the `FileService` from the `MemoryStream` and just use a `StreamContent`.