### PR TITLE
fix(ci): set Dependabot package-ecosystem to nuget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "nuget"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-


### PR DESCRIPTION
## Summary

- Sets `package-ecosystem` in `.github/dependabot.yml` from `""` to `"nuget"`, enabling automated NuGet dependency and security updates.

Closes #23

## Changes

| File | Change |
|------|--------|
| `.github/dependabot.yml` | `package-ecosystem: ""` → `package-ecosystem: "nuget"` |

## Verification

- No-code change (CI/CD configuration only) — no build/test impact.
- Dependabot will begin scanning NuGet packages on the next weekly schedule.