### PR TITLE
fix: Correct XML documentation copy-paste errors

### DIFF
--- a/src/PingenApiNet.Abstractions/Exceptions/PingenFileDownloadException.cs
+++ b/src/PingenApiNet.Abstractions/Exceptions/PingenFileDownloadException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -45,7 +45,7 @@ public class PingenFileDownloadException : ApplicationException
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PingenApiErrorException"/> class
+    /// Initializes a new instance of the <see cref="PingenFileDownloadException"/> class
     /// </summary>
     /// <param name="errorCode"></param>
     /// <param name="message"></param>
@@ -55,7 +55,7 @@ public class PingenFileDownloadException : ApplicationException
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PingenApiErrorException"/> class
+    /// Initializes a new instance of the <see cref="PingenFileDownloadException"/> class
     /// </summary>
     /// <param name="errorCode"></param>
     /// <param name="message"></param>

--- a/src/PingenApiNet.Abstractions/Exceptions/PingenWebhookValidationErrorException.cs
+++ b/src/PingenApiNet.Abstractions/Exceptions/PingenWebhookValidationErrorException.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -57,7 +57,7 @@ public class PingenWebhookValidationErrorException : ApplicationException
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PingenApiErrorException"/> class
+    /// Initializes a new instance of the <see cref="PingenWebhookValidationErrorException"/> class
     /// </summary>
     /// <param name="webhookEventData"></param>
     /// <param name="message"></param>

--- a/src/PingenApiNet/Services/Connectors/DistributionService.cs
+++ b/src/PingenApiNet/Services/Connectors/DistributionService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -39,7 +39,7 @@ namespace PingenApiNet.Services.Connectors;
 public sealed class DistributionService : ConnectorService, IDistributionService
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="LetterService"/> class.
+    /// Initializes a new instance of the <see cref="DistributionService"/> class.
     /// </summary>
     /// <param name="connectionHandler"></param>
     public DistributionService(IPingenConnectionHandler connectionHandler) : base(connectionHandler)


### PR DESCRIPTION
## Summary

Fixes XML `<see cref="..."/>` documentation tags that referenced wrong class names due to copy-paste errors:

- **`PingenFileDownloadException.cs`** — Two constructor summaries referenced `PingenApiErrorException` instead of `PingenFileDownloadException`
- **`PingenWebhookValidationErrorException.cs`** — One constructor summary referenced `PingenApiErrorException` instead of `PingenWebhookValidationErrorException`
- **`DistributionService.cs`** — Constructor summary referenced `LetterService` instead of `DistributionService`

Closes #31

## Test plan

- [ ] Verify IntelliSense shows correct class names in constructor documentation
- [ ] Confirm no build warnings related to XML documentation references