### PR TITLE
fix: use with-expression in AutoPage to prevent silent property loss

### DIFF
--- a/src/PingenApiNet.Tests/Tests/Unit/Services/Connectors/ConnectorServiceTests.cs
+++ b/src/PingenApiNet.Tests/Tests/Unit/Services/Connectors/ConnectorServiceTests.cs
@@ -139,6 +139,130 @@ public class ConnectorServiceTests
         result.ShouldBeNull();
     }
 
+    /// <summary>
+    /// Verifies AutoPage preserves all properties from the original ApiPagingRequest
+    /// </summary>
+    [Test]
+    public async Task AutoPage_PreservesAllRequestProperties()
+    {
+        var sorting = new[] { new KeyValuePair<string, CollectionSortDirection>("status", CollectionSortDirection.ASC) };
+        var filtering = new KeyValuePair<string, object>("and", new[] { new KeyValuePair<string, string>("status", "draft") });
+        var sparseFieldsets = new[] { new KeyValuePair<PingenApiDataType, IEnumerable<string>>(PingenApiDataType.letters, ["status"]) };
+        var includes = new[] { "organisation" };
+
+        var originalRequest = new ApiPagingRequest
+        {
+            Sorting = sorting,
+            Filtering = filtering,
+            Searching = "test-search",
+            PageNumber = 3,
+            PageLimit = 50,
+            SparseFieldsets = sparseFieldsets,
+            Include = includes
+        };
+
+        ApiPagingRequest? capturedRequest = null;
+
+        _mockConnectionHandler.GetAsync<CollectionResult<LetterData>>(
+            Arg.Any<string>(),
+            Arg.Do<ApiPagingRequest?>(r => capturedRequest = r),
+            Arg.Any<CancellationToken>()
+        ).Returns(Task.FromResult(new ApiResult<CollectionResult<LetterData>>
+        {
+            IsSuccess = true,
+            Data = new CollectionResult<LetterData>(
+                [CreateLetterData("letter-1")],
+                new CollectionResultLinks("", "", "", "", ""),
+                new CollectionResultMeta(1, 1, 50, 1, 1, 1)
+            )
+        }));
+
+        await foreach (var _ in _letterService.GetPageResultsAsync(originalRequest))
+        {
+            // consume the page
+        }
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Sorting.ShouldBe(sorting);
+        capturedRequest.Filtering.ShouldBe(filtering);
+        capturedRequest.Searching.ShouldBe("test-search");
+        capturedRequest.PageNumber.ShouldBe(3);
+        capturedRequest.PageLimit.ShouldBe(50);
+        capturedRequest.SparseFieldsets.ShouldBe(sparseFieldsets);
+        capturedRequest.Include.ShouldBe(includes);
+    }
+
+    /// <summary>
+    /// Verifies AutoPage defaults PageNumber to 1 when input request is null
+    /// </summary>
+    [Test]
+    public async Task AutoPage_NullRequest_DefaultsPageNumberToOne()
+    {
+        ApiPagingRequest? capturedRequest = null;
+
+        _mockConnectionHandler.GetAsync<CollectionResult<LetterData>>(
+            Arg.Any<string>(),
+            Arg.Do<ApiPagingRequest?>(r => capturedRequest = r),
+            Arg.Any<CancellationToken>()
+        ).Returns(Task.FromResult(new ApiResult<CollectionResult<LetterData>>
+        {
+            IsSuccess = true,
+            Data = new CollectionResult<LetterData>(
+                [CreateLetterData("letter-1")],
+                new CollectionResultLinks("", "", "", "", ""),
+                new CollectionResultMeta(1, 1, 20, 1, 1, 1)
+            )
+        }));
+
+        await foreach (var _ in _letterService.GetPageResultsAsync(null))
+        {
+            // consume the page
+        }
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.PageNumber.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// Verifies AutoPage defaults PageNumber to 1 when PageNumber is null in the request
+    /// </summary>
+    [Test]
+    public async Task AutoPage_NullPageNumber_DefaultsToOne()
+    {
+        var originalRequest = new ApiPagingRequest
+        {
+            Searching = "test",
+            PageNumber = null,
+            PageLimit = 25
+        };
+
+        ApiPagingRequest? capturedRequest = null;
+
+        _mockConnectionHandler.GetAsync<CollectionResult<LetterData>>(
+            Arg.Any<string>(),
+            Arg.Do<ApiPagingRequest?>(r => capturedRequest = r),
+            Arg.Any<CancellationToken>()
+        ).Returns(Task.FromResult(new ApiResult<CollectionResult<LetterData>>
+        {
+            IsSuccess = true,
+            Data = new CollectionResult<LetterData>(
+                [CreateLetterData("letter-1")],
+                new CollectionResultLinks("", "", "", "", ""),
+                new CollectionResultMeta(1, 1, 25, 1, 1, 1)
+            )
+        }));
+
+        await foreach (var _ in _letterService.GetPageResultsAsync(originalRequest))
+        {
+            // consume the page
+        }
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.PageNumber.ShouldBe(1);
+        capturedRequest.Searching.ShouldBe("test");
+        capturedRequest.PageLimit.ShouldBe(25);
+    }
+
     private static LetterData CreateLetterData(string id) => new()
     {
         Id = id,

--- a/src/PingenApiNet/Services/Connectors/Base/ConnectorService.cs
+++ b/src/PingenApiNet/Services/Connectors/Base/ConnectorService.cs
@@ -81,16 +81,7 @@ public abstract class ConnectorService : IConnectorService
     /// <exception cref="PingenApiErrorException"></exception>
     protected async IAsyncEnumerable<IEnumerable<TData>> AutoPage<TData>(ApiPagingRequest? apiPagingRequest, Func<ApiPagingRequest, Task<ApiResult<CollectionResult<TData>>>> getPage) where TData : IData
     {
-        var apiReRequest = new ApiPagingRequest
-        {
-            SparseFieldsets = apiPagingRequest?.SparseFieldsets,
-            Include = apiPagingRequest?.Include,
-            Sorting = apiPagingRequest?.Sorting,
-            Filtering = apiPagingRequest?.Filtering,
-            Searching = apiPagingRequest?.Searching,
-            PageNumber = apiPagingRequest?.PageNumber ?? 1,
-            PageLimit = apiPagingRequest?.PageLimit
-        };
+        var apiReRequest = (apiPagingRequest ?? new ApiPagingRequest()) with { PageNumber = apiPagingRequest?.PageNumber ?? 1 };
 
         ApiResult<CollectionResult<TData>> result;
         do


### PR DESCRIPTION
## Summary

- Replaced manual property copying in `ConnectorService.AutoPage` with a C# `with`-expression, making auto-pagination forward-compatible when `ApiPagingRequest` gains new properties
- Added 3 unit tests verifying property preservation and `PageNumber` defaulting behavior

Closes #30

## Changes

### `src/PingenApiNet/Services/Connectors/Base/ConnectorService.cs`

**Before:** Manual property-by-property copy (7 lines) — new properties on `ApiPagingRequest` would be silently dropped.

**After:**
```csharp
var apiReRequest = (apiPagingRequest ?? new ApiPagingRequest()) with { PageNumber = apiPagingRequest?.PageNumber ?? 1 };
```

### `src/PingenApiNet.Tests/Tests/Unit/Services/Connectors/ConnectorServiceTests.cs` (new)

- `AutoPage_PreservesAllRequestProperties` — verifies all properties survive through AutoPage
- `AutoPage_NullRequest_DefaultsPageNumberToOne` — null input defaults PageNumber to 1
- `AutoPage_NullPageNumber_DefaultsToOne` — null PageNumber defaults to 1, other properties preserved

## Verification

- Build: `dotnet build PingenApiNet.sln` — 0 warnings, 0 errors
- Tests: `dotnet test src/PingenApiNet.Tests/PingenApiNet.Tests.csproj` — 122 passed (119 existing + 3 new), 0 failed
- Verification agent: **APPROVED**

## Test plan

- [x] Build succeeds
- [x] All 122 unit tests pass
- [x] New tests cover null input, null PageNumber, and full property preservation
- [ ] Reviewer confirms `with`-expression semantics match previous manual copy behavior