### PR TITLE
fix: Fix resource leaks and improve error reporting in FilesService.UploadFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ if (!resultFilePath.IsSuccess)
 if (resultFilePath.Data?.Data is null)
     return "Failed to get file upload path from pingen, request was OK but return null";
 
-if (!await _pingenApiClient.Files.UploadFile(resultFilePath.Data.Data, contentStream))
-    return "Failed to upload file to pingen storage";
+var uploadResult = await _pingenApiClient.Files.UploadFile(resultFilePath.Data.Data, contentStream);
+if (!uploadResult.IsSuccess)
+    return $"Failed to upload file to pingen storage: {uploadResult.StatusCode} {uploadResult.ReasonPhrase}";
 ```
 
 Create the letter.

--- a/src/PingenApiNet.Abstractions/Models/Api/ExternalRequestResult.cs
+++ b/src/PingenApiNet.Abstractions/Models/Api/ExternalRequestResult.cs
@@ -1,0 +1,51 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Net;
+
+namespace PingenApiNet.Abstractions.Models.Api;
+
+/// <summary>
+/// Result of an external HTTP request (e.g., S3 file upload). Unlike <see cref="ApiResult"/>,
+/// this does not carry Pingen API-specific metadata such as request IDs or rate limit headers.
+/// </summary>
+public sealed record ExternalRequestResult
+{
+    /// <summary>
+    /// Indicates whether the HTTP request completed successfully (2xx status code)
+    /// </summary>
+    public bool IsSuccess { get; init; }
+
+    /// <summary>
+    /// The HTTP status code returned by the external server
+    /// </summary>
+    public HttpStatusCode StatusCode { get; init; }
+
+    /// <summary>
+    /// The reason phrase returned by the external server (e.g., "OK", "Forbidden", "Not Found").
+    /// May be null if the server did not include a reason phrase.
+    /// </summary>
+    public string? ReasonPhrase { get; init; }
+}

--- a/src/PingenApiNet.Tests.E2E/Tests/FileUpload.cs
+++ b/src/PingenApiNet.Tests.E2E/Tests/FileUpload.cs
@@ -72,7 +72,10 @@ public class TestGetFileUploadData : TestBase
         await File.OpenRead($"Assets/{fileName}").CopyToAsync(stream);
         var uploadRes = await PingenApiClient.Files.UploadFile(res.Data!.Data, stream);
 
-        uploadRes.ShouldBeTrue();
+        uploadRes.ShouldSatisfyAllConditions(
+            () => uploadRes.IsSuccess.ShouldBeTrue(),
+            () => uploadRes.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK)
+        );
 
         var letterMetaData = new LetterMetaData
         {

--- a/src/PingenApiNet.Tests/Tests/Unit/Models/ExternalRequestResultTests.cs
+++ b/src/PingenApiNet.Tests/Tests/Unit/Models/ExternalRequestResultTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using PingenApiNet.Abstractions.Models.Api;
+
+namespace PingenApiNet.Tests.Tests.Unit.Models;
+
+/// <summary>
+/// Unit tests for <see cref="ExternalRequestResult"/>
+/// </summary>
+public class ExternalRequestResultTests
+{
+    /// <summary>
+    /// Verifies default ExternalRequestResult properties
+    /// </summary>
+    [Test]
+    public void ExternalRequestResult_DefaultValues_AreCorrect()
+    {
+        var result = new ExternalRequestResult();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.StatusCode.ShouldBe(default(HttpStatusCode)),
+            () => result.ReasonPhrase.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies that ExternalRequestResult properties can be set via init
+    /// </summary>
+    [Test]
+    public void ExternalRequestResult_WithValues_StoresCorrectly()
+    {
+        var result = new ExternalRequestResult
+        {
+            IsSuccess = true,
+            StatusCode = HttpStatusCode.OK,
+            ReasonPhrase = "OK"
+        };
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.StatusCode.ShouldBe(HttpStatusCode.OK),
+            () => result.ReasonPhrase.ShouldBe("OK")
+        );
+    }
+
+    /// <summary>
+    /// Verifies record equality for ExternalRequestResult
+    /// </summary>
+    [Test]
+    public void ExternalRequestResult_RecordEquality_Works()
+    {
+        var result1 = new ExternalRequestResult
+        {
+            IsSuccess = true,
+            StatusCode = HttpStatusCode.OK,
+            ReasonPhrase = "OK"
+        };
+
+        var result2 = new ExternalRequestResult
+        {
+            IsSuccess = true,
+            StatusCode = HttpStatusCode.OK,
+            ReasonPhrase = "OK"
+        };
+
+        result1.ShouldBe(result2);
+    }
+
+    /// <summary>
+    /// Verifies record inequality for ExternalRequestResult with different status codes
+    /// </summary>
+    [Test]
+    public void ExternalRequestResult_DifferentStatusCodes_AreNotEqual()
+    {
+        var success = new ExternalRequestResult
+        {
+            IsSuccess = true,
+            StatusCode = HttpStatusCode.OK,
+            ReasonPhrase = "OK"
+        };
+
+        var failure = new ExternalRequestResult
+        {
+            IsSuccess = false,
+            StatusCode = HttpStatusCode.Forbidden,
+            ReasonPhrase = "Forbidden"
+        };
+
+        success.ShouldNotBe(failure);
+    }
+
+    /// <summary>
+    /// Verifies ExternalRequestResult with error status codes
+    /// </summary>
+    [Test]
+    public void ExternalRequestResult_ErrorStatusCodes_StoredCorrectly()
+    {
+        var result = new ExternalRequestResult
+        {
+            IsSuccess = false,
+            StatusCode = HttpStatusCode.ServiceUnavailable,
+            ReasonPhrase = "Service Unavailable"
+        };
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable),
+            () => result.ReasonPhrase.ShouldBe("Service Unavailable")
+        );
+    }
+}

--- a/src/PingenApiNet.Tests/Tests/Unit/Services/Connectors/FilesServiceTests.cs
+++ b/src/PingenApiNet.Tests/Tests/Unit/Services/Connectors/FilesServiceTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Files;
+using PingenApiNet.Services.Connectors;
+
+namespace PingenApiNet.Tests.Tests.Unit.Services.Connectors;
+
+/// <summary>
+/// Unit tests for <see cref="FilesService"/>
+/// </summary>
+public class FilesServiceTests
+{
+    private IPingenConnectionHandler _mockConnectionHandler = null!;
+    private FilesService _filesService = null!;
+
+    /// <summary>
+    /// Set up mocks before each test
+    /// </summary>
+    [SetUp]
+    public void SetUp()
+    {
+        _mockConnectionHandler = Substitute.For<IPingenConnectionHandler>();
+        _filesService = new FilesService(_mockConnectionHandler);
+    }
+
+    /// <summary>
+    /// Verifies GetPath calls ConnectionHandler.GetAsync with correct endpoint
+    /// </summary>
+    [Test]
+    public async Task GetPath_CallsConnectionHandlerWithCorrectPath()
+    {
+        _mockConnectionHandler
+            .GetAsync<SingleResult<FileUploadData>>(
+                "file-upload",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<FileUploadData>> { IsSuccess = true });
+
+        await _filesService.GetPath();
+
+        await _mockConnectionHandler.Received(1).GetAsync<SingleResult<FileUploadData>>(
+            "file-upload",
+            Arg.Any<ApiPagingRequest?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies UploadFile returns success result on 200 OK
+    /// </summary>
+    [Test]
+    public async Task UploadFile_Success_ReturnsSuccessResult()
+    {
+        var fileUploadData = CreateFileUploadData();
+        using var stream = new MemoryStream([0x25, 0x50, 0x44, 0x46]);
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Any<HttpRequestMessage>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var result = await _filesService.UploadFile(fileUploadData, stream);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.StatusCode.ShouldBe(HttpStatusCode.OK),
+            () => result.ReasonPhrase.ShouldBe("OK")
+        );
+    }
+
+    /// <summary>
+    /// Verifies UploadFile returns failure result on 403 Forbidden
+    /// </summary>
+    [Test]
+    public async Task UploadFile_Forbidden_ReturnsFailureResult()
+    {
+        var fileUploadData = CreateFileUploadData();
+        using var stream = new MemoryStream([0x25, 0x50, 0x44, 0x46]);
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Any<HttpRequestMessage>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.Forbidden));
+
+        var result = await _filesService.UploadFile(fileUploadData, stream);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.StatusCode.ShouldBe(HttpStatusCode.Forbidden),
+            () => result.ReasonPhrase.ShouldBe("Forbidden")
+        );
+    }
+
+    /// <summary>
+    /// Verifies UploadFile returns failure result on 500 Internal Server Error
+    /// </summary>
+    [Test]
+    public async Task UploadFile_InternalServerError_ReturnsFailureResult()
+    {
+        var fileUploadData = CreateFileUploadData();
+        using var stream = new MemoryStream([0x25, 0x50, 0x44, 0x46]);
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Any<HttpRequestMessage>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var result = await _filesService.UploadFile(fileUploadData, stream);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.StatusCode.ShouldBe(HttpStatusCode.InternalServerError)
+        );
+    }
+
+    /// <summary>
+    /// Verifies UploadFile sends PUT request to the correct URL
+    /// </summary>
+    [Test]
+    public async Task UploadFile_SendsPutRequestToCorrectUrl()
+    {
+        const string uploadUrl = "https://s3.example.com/bucket/file.pdf";
+        var fileUploadData = CreateFileUploadData(uploadUrl);
+        using var stream = new MemoryStream([0x25, 0x50, 0x44, 0x46]);
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Is<HttpRequestMessage>(r =>
+                    r.Method == HttpMethod.Put &&
+                    r.RequestUri!.ToString() == uploadUrl),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK));
+
+        await _filesService.UploadFile(fileUploadData, stream);
+
+        await _mockConnectionHandler.Received(1).SendExternalRequestAsync(
+            Arg.Is<HttpRequestMessage>(r =>
+                r.Method == HttpMethod.Put &&
+                r.RequestUri!.ToString() == uploadUrl),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies UploadFile sends StreamContent in the request
+    /// </summary>
+    [Test]
+    public async Task UploadFile_SendsStreamContent()
+    {
+        var fileUploadData = CreateFileUploadData();
+        using var stream = new MemoryStream([0x25, 0x50, 0x44, 0x46]);
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Is<HttpRequestMessage>(r => r.Content is StreamContent),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK));
+
+        await _filesService.UploadFile(fileUploadData, stream);
+
+        await _mockConnectionHandler.Received(1).SendExternalRequestAsync(
+            Arg.Is<HttpRequestMessage>(r => r.Content is StreamContent),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static FileUploadData CreateFileUploadData(string url = "https://s3.example.com/test")
+    {
+        return new FileUploadData
+        {
+            Id = "test-file-id",
+            Type = PingenApiDataType.file_uploads,
+            Attributes = new FileUpload(
+                Url: url,
+                UrlSignature: "test-signature",
+                ExpiresAt: DateTime.UtcNow.AddHours(1)
+            )
+        };
+    }
+}

--- a/src/PingenApiNet/Interfaces/Connectors/IFilesService.cs
+++ b/src/PingenApiNet/Interfaces/Connectors/IFilesService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -48,6 +48,6 @@ public interface IFilesService
     /// <param name="fileUploadData">Result from <see cref="GetPath"/></param>
     /// <param name="data">Binary file to upload as stream</param>
     /// <param name="cancellationToken">Optional, A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
-    /// <returns></returns>
-    public Task<bool> UploadFile(FileUploadData fileUploadData, Stream data, [Optional] CancellationToken cancellationToken);
+    /// <returns>An <see cref="ExternalRequestResult"/> indicating the outcome of the upload</returns>
+    public Task<ExternalRequestResult> UploadFile(FileUploadData fileUploadData, Stream data, [Optional] CancellationToken cancellationToken);
 }

--- a/src/PingenApiNet/Services/Connectors/FilesService.cs
+++ b/src/PingenApiNet/Services/Connectors/FilesService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using System.Net;
 using System.Runtime.InteropServices;
 using PingenApiNet.Abstractions.Models.Api;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
@@ -52,11 +53,20 @@ public sealed class FilesService : ConnectorService, IFilesService
     }
 
     /// <inheritdoc />
-    public async Task<bool> UploadFile(FileUploadData fileUploadData, Stream data, [Optional] CancellationToken cancellationToken)
+    public async Task<ExternalRequestResult> UploadFile(FileUploadData fileUploadData, Stream data, [Optional] CancellationToken cancellationToken)
     {
-        return (await ConnectionHandler.SendExternalRequestAsync(new(HttpMethod.Put, fileUploadData.Attributes.Url)
+        using var request = new HttpRequestMessage(HttpMethod.Put, fileUploadData.Attributes.Url)
         {
             Content = new StreamContent(data)
-        }, cancellationToken)).IsSuccessStatusCode;
+        };
+
+        using var response = await ConnectionHandler.SendExternalRequestAsync(request, cancellationToken);
+
+        return new ExternalRequestResult
+        {
+            IsSuccess = response.IsSuccessStatusCode,
+            StatusCode = response.StatusCode,
+            ReasonPhrase = response.ReasonPhrase
+        };
     }
 }


### PR DESCRIPTION
## Summary

- **Fix resource leaks:** Wrap `HttpRequestMessage` and `HttpResponseMessage` in `using var` declarations in `FilesService.UploadFile` to ensure proper disposal
- **Improve error reporting:** Replace bare `bool` return type with new `ExternalRequestResult` sealed record providing `IsSuccess`, `StatusCode` (HttpStatusCode), and `ReasonPhrase` for meaningful error diagnosis
- **New type in Abstractions:** `ExternalRequestResult` is intentionally separate from `ApiResult` since S3 upload responses lack Pingen API-specific metadata (RequestId, rate limits, etc.)

## Changes

| File | Action |
|------|--------|
| `src/PingenApiNet.Abstractions/Models/Api/ExternalRequestResult.cs` | **NEW** — Sealed record for external HTTP request results |
| `src/PingenApiNet/Interfaces/Connectors/IFilesService.cs` | **MODIFIED** — Return type `Task<bool>` → `Task<ExternalRequestResult>` |
| `src/PingenApiNet/Services/Connectors/FilesService.cs` | **MODIFIED** — `using var` disposal + new return type |
| `src/PingenApiNet.Tests.E2E/Tests/FileUpload.cs` | **MODIFIED** — Updated assertion to use `ExternalRequestResult` |
| `src/PingenApiNet.Tests/Tests/Unit/Services/Connectors/FilesServiceTests.cs` | **NEW** — 6 unit tests for FilesService |
| `src/PingenApiNet.Tests/Tests/Unit/Models/ExternalRequestResultTests.cs` | **NEW** — 5 unit tests for ExternalRequestResult |
| `README.md` | **MODIFIED** — Usage example shows error reporting with StatusCode/ReasonPhrase |

## Breaking Change

This is a **binary-breaking change**: `IFilesService.UploadFile` return type changes from `Task<bool>` to `Task<ExternalRequestResult>`. Migration: replace `result` with `result.IsSuccess`, and optionally log `result.StatusCode`/`result.ReasonPhrase` on failure.

## Verification

- Build: 0 warnings, 0 errors
- Tests: 130 passed (119 original + 11 new), 0 failed
- Verification agent: **APPROVED** — all acceptance criteria met

## Test plan

- [x] Solution builds with zero warnings/errors
- [x] All 130 unit tests pass (119 existing + 11 new)
- [x] `ExternalRequestResult` follows project conventions (sealed record, init-only, XML docs, MIT header)
- [x] Resource disposal verified via `using var` on both `HttpRequestMessage` and `HttpResponseMessage`
- [ ] E2E tests pass against staging API (requires credentials)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)