### PR TITLE
feat(tests): Wave 1 unit tests — service edge cases & error scenarios (#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Offline unit tests that require no API credentials or network access. Uses **NUn
 - `Helpers/` — `PingenSerialisationHelper`, `PingenWebhookHelper`, `PingenAttributesPropertyHelper`, `PingenDateTimeConverter(Nullable)`, `PingenKeyValuePairStringObjectConverter`.
 - `Models/` — `ApiResult`, `DataPost`/`DataPatch`, `ExternalRequestResult`, `IncludedCollection`, `PingenConfiguration`.
 - `Services/` — `PingenApiClient` facade + `PingenConnectionHandler` (OAuth token lifecycle, re-auth, rate-limit header parsing, multi-tenant token isolation regression test for #22, concurrent-login double-check regression for #27).
-- `Services/Connectors/` — per-connector unit tests using NSubstitute-mocked `IPingenConnectionHandler` (verifies endpoint path construction for Batches, Distribution, Files, Letters, Organisations, Users, Webhooks, and the shared `ConnectorService`).
+- `Services/Connectors/` — per-connector unit tests using NSubstitute-mocked `IPingenConnectionHandler` (verifies endpoint path construction and error/edge-case handling for Batches, Distribution, Files, Letters, Organisations, Users, Webhooks, and the shared `ConnectorService`).
 - `AspNetCore/` — `PingenServiceCollection.AddPingenServices()` DI registration.
 - `Enums/` — `BatchIconSerializationTests` (hyphenated enum-member serialization).
 - `Exceptions/` — the three Pingen exception types.

--- a/doc/analysis/2026-04-20-test-coverage-roadmap.md
+++ b/doc/analysis/2026-04-20-test-coverage-roadmap.md
@@ -88,7 +88,7 @@
 ### Wave 1: Unit Tests — Service Edge Cases & Error Scenarios
 
 **Phase 1 of 2 (Complete):** Batch, Distribution, Files, Letter services.
-**Phase 2 of 2 (Pending):** Organisation, User, Webhook, and `PingenConnectionHandler`.
+**Phase 2 of 2 (Complete):** Organisation, User, Webhook, and `PingenConnectionHandler`.
 
 **Scope:** `tests/PingenApiNet.UnitTests/Tests/Services/Connectors/`
 

--- a/doc/analysis/2026-04-20-test-coverage-roadmap.md
+++ b/doc/analysis/2026-04-20-test-coverage-roadmap.md
@@ -31,7 +31,7 @@
 ### Current Coverage Baseline
 | Tier | Status |
 |---|---|
-| Unit | Test classes exist for all 7 services + helpers; error/edge cases sparse |
+| Unit | Test classes exist for all 7 services + helpers; error/edge cases covered for Batch, Distribution, Files, and Letter services (Wave 1 Phase 1 complete) |
 | Integration | Test classes exist for all 7 services; cross-cutting scenarios missing |
 | E2E | Only 4 scenarios: Distribution, FileUpload, LettersGetAll, RateLimit |
 
@@ -86,6 +86,9 @@
 ---
 
 ### Wave 1: Unit Tests — Service Edge Cases & Error Scenarios
+
+**Phase 1 of 2 (Complete):** Batch, Distribution, Files, Letter services.
+**Phase 2 of 2 (Pending):** Organisation, User, Webhook, and `PingenConnectionHandler`.
 
 **Scope:** `tests/PingenApiNet.UnitTests/Tests/Services/Connectors/`
 

--- a/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/BatchServiceTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/BatchServiceTests.cs
@@ -50,6 +50,33 @@ public class BatchServiceTests
     }
 
     /// <summary>
+    /// Verifies GetPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetPage_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("validation_failed", "Invalid request");
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<BatchData>>(
+                "batches",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<BatchData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _batchService.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
     /// Verifies Get calls ConnectionHandler with correct path including batch ID
     /// </summary>
     [Test]
@@ -73,26 +100,60 @@ public class BatchServiceTests
     }
 
     /// <summary>
+    /// Verifies Get propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Get_ApiError_ReturnsFailureResult()
+    {
+        const string batchId = "missing-batch";
+        var apiError = CreateApiError("not_found", "Batch not found");
+        _mockConnectionHandler
+            .GetAsync<SingleResult<BatchDataDetailed>>(
+                $"batches/{batchId}",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<BatchDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _batchService.Get(batchId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
+    /// Verifies Get with an empty ID constructs an endpoint path with a trailing slash and does not throw
+    /// </summary>
+    [Test]
+    public async Task Get_EmptyId_ConstructsTrailingSlashPath()
+    {
+        _mockConnectionHandler
+            .GetAsync<SingleResult<BatchDataDetailed>>(
+                "batches/",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<BatchDataDetailed>> { IsSuccess = true });
+
+        await _batchService.Get(string.Empty);
+
+        await _mockConnectionHandler.Received(1).GetAsync<SingleResult<BatchDataDetailed>>(
+            "batches/",
+            Arg.Any<ApiRequest?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Verifies Create calls ConnectionHandler.PostAsync with correct endpoint and payload type
     /// </summary>
     [Test]
     public async Task Create_CallsConnectionHandlerWithCorrectPath()
     {
-        var data = new DataPost<BatchCreate, BatchCreateRelationships>
-        {
-            Type = PingenApiDataType.batches,
-            Attributes = new BatchCreate
-            {
-                Name = "Test Batch",
-                Icon = BatchIcon.campaign,
-                FileOriginalName = "batch.pdf",
-                FileUrl = "https://example.com/batch.pdf",
-                FileUrlSignature = "sig",
-                AddressPosition = LetterAddressPosition.left,
-                GroupingType = BatchGroupingType.zip,
-                GroupingOptionsSplitType = BatchGroupingOptionsSplitType.file
-            }
-        };
+        var data = CreateBatchPost();
 
         _mockConnectionHandler
             .PostAsync<SingleResult<BatchDataDetailed>, DataPost<BatchCreate, BatchCreateRelationships>>(
@@ -110,4 +171,80 @@ public class BatchServiceTests
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
+
+    /// <summary>
+    /// Verifies Create propagates failure ApiResult without throwing when the API rejects the payload
+    /// </summary>
+    [Test]
+    public async Task Create_ApiError_ReturnsFailureResult()
+    {
+        var data = CreateBatchPost();
+        var apiError = CreateApiError("unprocessable_entity", "File URL signature is invalid");
+        _mockConnectionHandler
+            .PostAsync<SingleResult<BatchDataDetailed>, DataPost<BatchCreate, BatchCreateRelationships>>(
+                "batches",
+                Arg.Any<DataPost<BatchCreate, BatchCreateRelationships>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<BatchDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _batchService.Create(data);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies Create forwards the supplied idempotency key through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task Create_WithIdempotencyKey_ForwardsKeyToConnectionHandler()
+    {
+        const string idempotencyKey = "batch-idem-1";
+        var data = CreateBatchPost();
+
+        _mockConnectionHandler
+            .PostAsync<SingleResult<BatchDataDetailed>, DataPost<BatchCreate, BatchCreateRelationships>>(
+                "batches",
+                Arg.Any<DataPost<BatchCreate, BatchCreateRelationships>>(),
+                idempotencyKey,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<BatchDataDetailed>> { IsSuccess = true });
+
+        await _batchService.Create(data, idempotencyKey);
+
+        await _mockConnectionHandler.Received(1).PostAsync<SingleResult<BatchDataDetailed>, DataPost<BatchCreate, BatchCreateRelationships>>(
+            "batches",
+            Arg.Any<DataPost<BatchCreate, BatchCreateRelationships>>(),
+            idempotencyKey,
+            Arg.Any<CancellationToken>());
+    }
+
+    private static DataPost<BatchCreate, BatchCreateRelationships> CreateBatchPost() => new()
+    {
+        Type = PingenApiDataType.batches,
+        Attributes = new BatchCreate
+        {
+            Name = "Test Batch",
+            Icon = BatchIcon.campaign,
+            FileOriginalName = "batch.pdf",
+            FileUrl = "https://example.com/batch.pdf",
+            FileUrlSignature = "sig",
+            AddressPosition = LetterAddressPosition.left,
+            GroupingType = BatchGroupingType.zip,
+            GroupingOptionsSplitType = BatchGroupingOptionsSplitType.file
+        }
+    };
+
+    private static ApiError CreateApiError(string code, string detail) => new(
+    [
+        new ApiErrorData(code, "Error", detail, new ApiErrorSource(string.Empty, string.Empty))
+    ]);
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/DistributionServiceTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/DistributionServiceTests.cs
@@ -1,5 +1,7 @@
 using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Exceptions;
 using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults.Embedded;
 using PingenApiNet.Abstractions.Models.DeliveryProducts;
@@ -47,6 +49,56 @@ public class DistributionServiceTests
     }
 
     /// <summary>
+    /// Verifies GetDeliveryProductsPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetDeliveryProductsPage_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("server_error", "Service unavailable");
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<DeliveryProductData>>(
+                "distribution/delivery-products",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<DeliveryProductData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _distributionService.GetDeliveryProductsPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies GetDeliveryProductsPage forwards the supplied paging request through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task GetDeliveryProductsPage_WithPagingRequest_ForwardsRequestToConnectionHandler()
+    {
+        var pagingRequest = new ApiPagingRequest { PageNumber = 2, PageLimit = 50 };
+
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<DeliveryProductData>>(
+                "distribution/delivery-products",
+                pagingRequest,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<DeliveryProductData>> { IsSuccess = true });
+
+        await _distributionService.GetDeliveryProductsPage(pagingRequest);
+
+        await _mockConnectionHandler.Received(1).GetAsync<CollectionResult<DeliveryProductData>>(
+            "distribution/delivery-products",
+            pagingRequest,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Verifies GetDeliveryProductsPageResultsAsync calls ConnectionHandler and returns pages via auto-pagination
     /// </summary>
     [Test]
@@ -78,10 +130,41 @@ public class DistributionServiceTests
         pages[0].First().Id.ShouldBe("product-1");
     }
 
+    /// <summary>
+    /// Verifies GetDeliveryProductsPageResultsAsync surfaces an API failure as a <see cref="PingenApiErrorException"/>
+    /// </summary>
+    [Test]
+    public async Task GetDeliveryProductsPageResultsAsync_ApiError_ThrowsPingenApiErrorException()
+    {
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<DeliveryProductData>>(
+                "distribution/delivery-products",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<DeliveryProductData>>
+            {
+                IsSuccess = false,
+                ApiError = CreateApiError("server_error", "boom")
+            });
+
+        await Should.ThrowAsync<PingenApiErrorException>(async () =>
+        {
+            await foreach (var _ in _distributionService.GetDeliveryProductsPageResultsAsync())
+            {
+                // consume pages
+            }
+        });
+    }
+
     private static DeliveryProductData CreateDeliveryProductData(string id) => new()
     {
         Id = id,
         Type = PingenApiDataType.delivery_products,
         Attributes = new DeliveryProduct(null, null, null, null, null, null, null)
     };
+
+    private static ApiError CreateApiError(string code, string detail) => new(
+    [
+        new ApiErrorData(code, "Error", detail, new ApiErrorSource(string.Empty, string.Empty))
+    ]);
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/FilesServiceTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/FilesServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using PingenApiNet.Abstractions.Enums.Api;
 using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
 using PingenApiNet.Abstractions.Models.Files;
 using PingenApiNet.Services.Connectors;
@@ -44,6 +45,33 @@ public class FilesServiceTests
             "file-upload",
             Arg.Any<ApiPagingRequest?>(),
             Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies GetPath propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetPath_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("forbidden", "Token does not allow file upload");
+        _mockConnectionHandler
+            .GetAsync<SingleResult<FileUploadData>>(
+                "file-upload",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<FileUploadData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _filesService.GetPath();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
     }
 
     /// <summary>
@@ -118,6 +146,29 @@ public class FilesServiceTests
     }
 
     /// <summary>
+    /// Verifies UploadFile returns failure result on 408 Request Timeout
+    /// </summary>
+    [Test]
+    public async Task UploadFile_RequestTimeout_ReturnsFailureResult()
+    {
+        var fileUploadData = CreateFileUploadData();
+        using var stream = new MemoryStream([0x25, 0x50, 0x44, 0x46]);
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Any<HttpRequestMessage>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.RequestTimeout));
+
+        var result = await _filesService.UploadFile(fileUploadData, stream);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.StatusCode.ShouldBe(HttpStatusCode.RequestTimeout)
+        );
+    }
+
+    /// <summary>
     /// Verifies UploadFile sends PUT request to the correct URL
     /// </summary>
     [Test]
@@ -166,6 +217,52 @@ public class FilesServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// Verifies UploadFile throws <see cref="ArgumentNullException"/> when the data stream is null
+    /// </summary>
+    [Test]
+    public async Task UploadFile_NullStream_ThrowsArgumentNullException()
+    {
+        var fileUploadData = CreateFileUploadData();
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await _filesService.UploadFile(fileUploadData, null!));
+    }
+
+    /// <summary>
+    /// Verifies UploadFile throws <see cref="NullReferenceException"/> when the file upload data is null
+    /// </summary>
+    [Test]
+    public async Task UploadFile_NullFileUploadData_ThrowsNullReferenceException()
+    {
+        using var stream = new MemoryStream([0x25, 0x50, 0x44, 0x46]);
+
+        await Should.ThrowAsync<NullReferenceException>(async () =>
+            await _filesService.UploadFile(null!, stream));
+    }
+
+    /// <summary>
+    /// Verifies UploadFile does not invoke the connection handler when the data stream is null
+    /// </summary>
+    [Test]
+    public async Task UploadFile_NullStream_DoesNotInvokeConnectionHandler()
+    {
+        var fileUploadData = CreateFileUploadData();
+
+        try
+        {
+            await _filesService.UploadFile(fileUploadData, null!);
+        }
+        catch (ArgumentNullException)
+        {
+            // expected — see UploadFile_NullStream_ThrowsArgumentNullException
+        }
+
+        await _mockConnectionHandler.DidNotReceive().SendExternalRequestAsync(
+            Arg.Any<HttpRequestMessage>(),
+            Arg.Any<CancellationToken>());
+    }
+
     private static FileUploadData CreateFileUploadData(string url = "https://s3.example.com/test")
     {
         return new FileUploadData
@@ -179,4 +276,9 @@ public class FilesServiceTests
             )
         };
     }
+
+    private static ApiError CreateApiError(string code, string detail) => new(
+    [
+        new ApiErrorData(code, "Error", detail, new ApiErrorSource(string.Empty, string.Empty))
+    ]);
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/LetterServiceTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/LetterServiceTests.cs
@@ -1,9 +1,12 @@
+using System.Net;
 using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Enums.Letters;
+using PingenApiNet.Abstractions.Exceptions;
 using PingenApiNet.Abstractions.Models.Api;
 using PingenApiNet.Abstractions.Models.Api.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
-using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults.Embedded;
 using PingenApiNet.Abstractions.Models.LetterEvents;
+using PingenApiNet.Abstractions.Models.LetterPrices;
 using PingenApiNet.Abstractions.Models.Letters;
 using PingenApiNet.Abstractions.Models.Letters.Views;
 using PingenApiNet.Services.Connectors;
@@ -50,6 +53,33 @@ public class LetterServiceTests
     }
 
     /// <summary>
+    /// Verifies GetPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetPage_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("server_error", "Service unavailable");
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<LetterData>>(
+                "letters",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<LetterData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
     /// Verifies Get calls ConnectionHandler.GetAsync with correct path including letter ID
     /// </summary>
     [Test]
@@ -69,6 +99,54 @@ public class LetterServiceTests
         await _mockConnectionHandler.Received(1).GetAsync<SingleResult<LetterDataDetailed>>(
             $"letters/{letterId}",
             Arg.Any<ApiPagingRequest?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies Get propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Get_ApiError_ReturnsFailureResult()
+    {
+        const string letterId = "missing-letter";
+        var apiError = CreateApiError("not_found", "Letter not found");
+        _mockConnectionHandler
+            .GetAsync<SingleResult<LetterDataDetailed>>(
+                $"letters/{letterId}",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.Get(letterId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
+    /// Verifies Get with an empty ID constructs an endpoint path with a trailing slash and does not throw
+    /// </summary>
+    [Test]
+    public async Task Get_EmptyId_ConstructsTrailingSlashPath()
+    {
+        _mockConnectionHandler
+            .GetAsync<SingleResult<LetterDataDetailed>>(
+                "letters/",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>> { IsSuccess = true });
+
+        await _letterService.Get(string.Empty);
+
+        await _mockConnectionHandler.Received(1).GetAsync<SingleResult<LetterDataDetailed>>(
+            "letters/",
+            Arg.Any<ApiRequest?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -94,6 +172,32 @@ public class LetterServiceTests
     }
 
     /// <summary>
+    /// Verifies Delete propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Delete_ApiError_ReturnsFailureResult()
+    {
+        const string letterId = "delete-letter-id";
+        var apiError = CreateApiError("conflict", "Letter cannot be deleted in current state");
+        _mockConnectionHandler
+            .DeleteAsync(
+                $"letters/{letterId}",
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.Delete(letterId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
     /// Verifies Cancel calls ConnectionHandler.PatchAsync with correct cancel path
     /// </summary>
     [Test]
@@ -113,6 +217,57 @@ public class LetterServiceTests
         await _mockConnectionHandler.Received(1).PatchAsync(
             $"letters/{letterId}/cancel",
             Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies Cancel propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Cancel_ApiError_ReturnsFailureResult()
+    {
+        const string letterId = "cancel-letter-id";
+        var apiError = CreateApiError("conflict", "Letter cannot be cancelled in current state");
+        _mockConnectionHandler
+            .PatchAsync(
+                $"letters/{letterId}/cancel",
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.Cancel(letterId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
+    /// Verifies Cancel forwards the supplied idempotency key through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task Cancel_WithIdempotencyKey_ForwardsKeyToConnectionHandler()
+    {
+        const string letterId = "cancel-letter-id";
+        const string idempotencyKey = "cancel-idem-1";
+
+        _mockConnectionHandler
+            .PatchAsync(
+                $"letters/{letterId}/cancel",
+                idempotencyKey,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult { IsSuccess = true });
+
+        await _letterService.Cancel(letterId, idempotencyKey);
+
+        await _mockConnectionHandler.Received(1).PatchAsync(
+            $"letters/{letterId}/cancel",
+            idempotencyKey,
             Arg.Any<CancellationToken>());
     }
 
@@ -140,26 +295,39 @@ public class LetterServiceTests
     }
 
     /// <summary>
+    /// Verifies GetFileLocation propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetFileLocation_ApiError_ReturnsFailureResult()
+    {
+        const string letterId = "file-letter-id";
+        var apiError = CreateApiError("not_found", "Letter file not available");
+        _mockConnectionHandler
+            .GetAsync(
+                $"letters/{letterId}/file",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.GetFileLocation(letterId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
     /// Verifies Create calls ConnectionHandler.PostAsync with correct path
     /// </summary>
     [Test]
     public async Task Create_CallsConnectionHandlerWithCorrectPath()
     {
-        var data = new DataPost<LetterCreate, LetterCreateRelationships>
-        {
-            Type = PingenApiDataType.letters,
-            Attributes = new LetterCreate
-            {
-                FileOriginalName = "test.pdf",
-                FileUrl = "https://example.com/test.pdf",
-                FileUrlSignature = "sig",
-                AddressPosition = Abstractions.Enums.Letters.LetterAddressPosition.left,
-                AutoSend = false,
-                DeliveryProduct = "cheap",
-                PrintMode = Abstractions.Enums.Letters.LetterPrintMode.simplex,
-                PrintSpectrum = Abstractions.Enums.Letters.LetterPrintSpectrum.grayscale
-            }
-        };
+        var data = CreateLetterPost();
 
         _mockConnectionHandler
             .PostAsync<SingleResult<LetterDataDetailed>, DataPost<LetterCreate, LetterCreateRelationships>>(
@@ -179,6 +347,244 @@ public class LetterServiceTests
     }
 
     /// <summary>
+    /// Verifies Create propagates failure ApiResult without throwing when the API rejects the payload
+    /// </summary>
+    [Test]
+    public async Task Create_ApiError_ReturnsFailureResult()
+    {
+        var data = CreateLetterPost();
+        var apiError = CreateApiError("unprocessable_entity", "File URL signature invalid");
+        _mockConnectionHandler
+            .PostAsync<SingleResult<LetterDataDetailed>, DataPost<LetterCreate, LetterCreateRelationships>>(
+                "letters",
+                Arg.Any<DataPost<LetterCreate, LetterCreateRelationships>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.Create(data);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies Create forwards the supplied idempotency key through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task Create_WithIdempotencyKey_ForwardsKeyToConnectionHandler()
+    {
+        const string idempotencyKey = "create-idem-1";
+        var data = CreateLetterPost();
+
+        _mockConnectionHandler
+            .PostAsync<SingleResult<LetterDataDetailed>, DataPost<LetterCreate, LetterCreateRelationships>>(
+                "letters",
+                Arg.Any<DataPost<LetterCreate, LetterCreateRelationships>>(),
+                idempotencyKey,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>> { IsSuccess = true });
+
+        await _letterService.Create(data, idempotencyKey);
+
+        await _mockConnectionHandler.Received(1).PostAsync<SingleResult<LetterDataDetailed>, DataPost<LetterCreate, LetterCreateRelationships>>(
+            "letters",
+            Arg.Any<DataPost<LetterCreate, LetterCreateRelationships>>(),
+            idempotencyKey,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies Send calls ConnectionHandler.PatchAsync with correct send path including the letter ID
+    /// </summary>
+    [Test]
+    public async Task Send_CallsConnectionHandlerWithCorrectPath()
+    {
+        const string letterId = "send-letter-id";
+        var data = CreateLetterSendPatch(letterId);
+
+        _mockConnectionHandler
+            .PatchAsync<SingleResult<LetterDataDetailed>, DataPatch<LetterSend>>(
+                $"letters/{letterId}/send",
+                Arg.Any<DataPatch<LetterSend>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>> { IsSuccess = true });
+
+        await _letterService.Send(data);
+
+        await _mockConnectionHandler.Received(1).PatchAsync<SingleResult<LetterDataDetailed>, DataPatch<LetterSend>>(
+            $"letters/{letterId}/send",
+            Arg.Any<DataPatch<LetterSend>>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies Send propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Send_ApiError_ReturnsFailureResult()
+    {
+        const string letterId = "send-letter-id";
+        var data = CreateLetterSendPatch(letterId);
+        var apiError = CreateApiError("conflict", "Letter is not in a valid state to send");
+        _mockConnectionHandler
+            .PatchAsync<SingleResult<LetterDataDetailed>, DataPatch<LetterSend>>(
+                $"letters/{letterId}/send",
+                Arg.Any<DataPatch<LetterSend>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.Send(data);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
+    /// Verifies Send throws <see cref="NullReferenceException"/> when the patch data is null because the service dereferences <c>data.Id</c> to build the endpoint path
+    /// </summary>
+    [Test]
+    public async Task Send_NullData_ThrowsNullReferenceException()
+    {
+        await Should.ThrowAsync<NullReferenceException>(async () =>
+            await _letterService.Send(null!));
+    }
+
+    /// <summary>
+    /// Verifies Update calls ConnectionHandler.PatchAsync with correct path including the letter ID
+    /// </summary>
+    [Test]
+    public async Task Update_CallsConnectionHandlerWithCorrectPath()
+    {
+        const string letterId = "update-letter-id";
+        var data = CreateLetterUpdatePatch(letterId);
+
+        _mockConnectionHandler
+            .PatchAsync<SingleResult<LetterDataDetailed>, DataPatch<LetterUpdate>>(
+                $"letters/{letterId}",
+                Arg.Any<DataPatch<LetterUpdate>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>> { IsSuccess = true });
+
+        await _letterService.Update(data);
+
+        await _mockConnectionHandler.Received(1).PatchAsync<SingleResult<LetterDataDetailed>, DataPatch<LetterUpdate>>(
+            $"letters/{letterId}",
+            Arg.Any<DataPatch<LetterUpdate>>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies Update propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Update_ApiError_ReturnsFailureResult()
+    {
+        const string letterId = "update-letter-id";
+        var data = CreateLetterUpdatePatch(letterId);
+        var apiError = CreateApiError("unprocessable_entity", "Paper type is invalid");
+        _mockConnectionHandler
+            .PatchAsync<SingleResult<LetterDataDetailed>, DataPatch<LetterUpdate>>(
+                $"letters/{letterId}",
+                Arg.Any<DataPatch<LetterUpdate>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.Update(data);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
+    /// Verifies Update throws <see cref="NullReferenceException"/> when the patch data is null because the service dereferences <c>data.Id</c> to build the endpoint path
+    /// </summary>
+    [Test]
+    public async Task Update_NullData_ThrowsNullReferenceException()
+    {
+        await Should.ThrowAsync<NullReferenceException>(async () =>
+            await _letterService.Update(null!));
+    }
+
+    /// <summary>
+    /// Verifies CalculatePrice calls ConnectionHandler.PostAsync with correct price-calculator path
+    /// </summary>
+    [Test]
+    public async Task CalculatePrice_CallsConnectionHandlerWithCorrectPath()
+    {
+        var data = CreateLetterPriceConfigurationPost();
+
+        _mockConnectionHandler
+            .PostAsync<SingleResult<LetterPriceData>, DataPost<LetterPriceConfiguration>>(
+                "letters/price-calculator",
+                Arg.Any<DataPost<LetterPriceConfiguration>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterPriceData>> { IsSuccess = true });
+
+        await _letterService.CalculatePrice(data);
+
+        await _mockConnectionHandler.Received(1).PostAsync<SingleResult<LetterPriceData>, DataPost<LetterPriceConfiguration>>(
+            "letters/price-calculator",
+            Arg.Any<DataPost<LetterPriceConfiguration>>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies CalculatePrice propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task CalculatePrice_ApiError_ReturnsFailureResult()
+    {
+        var data = CreateLetterPriceConfigurationPost();
+        var apiError = CreateApiError("unprocessable_entity", "Country code is invalid");
+        _mockConnectionHandler
+            .PostAsync<SingleResult<LetterPriceData>, DataPost<LetterPriceConfiguration>>(
+                "letters/price-calculator",
+                Arg.Any<DataPost<LetterPriceConfiguration>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<LetterPriceData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.CalculatePrice(data);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
     /// Verifies DownloadFileContent throws PingenFileDownloadException on failed download
     /// </summary>
     [Test]
@@ -190,13 +596,86 @@ public class LetterServiceTests
             .SendExternalRequestAsync(
                 Arg.Any<HttpRequestMessage>(),
                 Arg.Any<CancellationToken>())
-            .Returns(new HttpResponseMessage(System.Net.HttpStatusCode.Forbidden)
+            .Returns(new HttpResponseMessage(HttpStatusCode.Forbidden)
             {
                 Content = new StringContent("<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>")
             });
 
-        await Should.ThrowAsync<Abstractions.Exceptions.PingenFileDownloadException>(
+        await Should.ThrowAsync<PingenFileDownloadException>(
             async () => await _letterService.DownloadFileContent(fileUrl));
+    }
+
+    /// <summary>
+    /// Verifies DownloadFileContent extracts the AWS-style error code from the response body and exposes it on the thrown exception
+    /// </summary>
+    [Test]
+    public async Task DownloadFileContent_FailedRequest_ExtractsErrorCodeOntoException()
+    {
+        var fileUrl = new Uri("https://example.com/file.pdf");
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Any<HttpRequestMessage>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent("<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>")
+            });
+
+        var ex = await Should.ThrowAsync<PingenFileDownloadException>(
+            async () => await _letterService.DownloadFileContent(fileUrl));
+        ex.ErrorCode.ShouldBe("AccessDenied");
+    }
+
+    /// <summary>
+    /// Verifies DownloadFileContent throws <see cref="PingenFileDownloadException"/> with an empty error code when the AWS response body has no <c>Code</c> element
+    /// </summary>
+    [Test]
+    public async Task DownloadFileContent_FailedRequestMissingErrorCode_ThrowsPingenFileDownloadExceptionWithEmptyCode()
+    {
+        var fileUrl = new Uri("https://example.com/file.pdf");
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Any<HttpRequestMessage>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent("<Error><Message>Access Denied</Message></Error>")
+            });
+
+        var ex = await Should.ThrowAsync<PingenFileDownloadException>(
+            async () => await _letterService.DownloadFileContent(fileUrl));
+        ex.ErrorCode.ShouldBe(string.Empty);
+    }
+
+    /// <summary>
+    /// Verifies DownloadFileContent issues an HTTP GET request against the supplied file URL
+    /// </summary>
+    [Test]
+    public async Task DownloadFileContent_SendsGetRequestToCorrectUrl()
+    {
+        var fileUrl = new Uri("https://files.example.com/letter.pdf");
+        var content = new byte[] { 0x25, 0x50, 0x44, 0x46 };
+
+        _mockConnectionHandler
+            .SendExternalRequestAsync(
+                Arg.Is<HttpRequestMessage>(r =>
+                    r.Method == HttpMethod.Get &&
+                    r.RequestUri == fileUrl),
+                Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(content)
+            });
+
+        await _letterService.DownloadFileContent(fileUrl);
+
+        await _mockConnectionHandler.Received(1).SendExternalRequestAsync(
+            Arg.Is<HttpRequestMessage>(r =>
+                r.Method == HttpMethod.Get &&
+                r.RequestUri == fileUrl),
+            Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -212,7 +691,7 @@ public class LetterServiceTests
             .SendExternalRequestAsync(
                 Arg.Any<HttpRequestMessage>(),
                 Arg.Any<CancellationToken>())
-            .Returns(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new ByteArrayContent(content)
             });
@@ -249,6 +728,36 @@ public class LetterServiceTests
     }
 
     /// <summary>
+    /// Verifies GetEventsPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetEventsPage_ApiError_ReturnsFailureResult()
+    {
+        const string letterId = "test-letter-id";
+        const string language = "en";
+        var expectedPath = $"letters/{letterId}/events?language={Uri.EscapeDataString(language)}";
+        var apiError = CreateApiError("not_found", "Letter not found");
+
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<LetterEventData>>(
+                expectedPath,
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<LetterEventData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.GetEventsPage(letterId, language);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
     /// Verifies GetIssuesPage URL-encodes the language parameter value
     /// </summary>
     [Test]
@@ -271,4 +780,89 @@ public class LetterServiceTests
             Arg.Any<ApiPagingRequest?>(),
             Arg.Any<CancellationToken>());
     }
+
+    /// <summary>
+    /// Verifies GetIssuesPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetIssuesPage_ApiError_ReturnsFailureResult()
+    {
+        const string language = "en";
+        var expectedPath = $"letters/issues?language={Uri.EscapeDataString(language)}";
+        var apiError = CreateApiError("server_error", "Service unavailable");
+
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<LetterEventData>>(
+                expectedPath,
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<LetterEventData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _letterService.GetIssuesPage(language);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    private static DataPost<LetterCreate, LetterCreateRelationships> CreateLetterPost() => new()
+    {
+        Type = PingenApiDataType.letters,
+        Attributes = new LetterCreate
+        {
+            FileOriginalName = "test.pdf",
+            FileUrl = "https://example.com/test.pdf",
+            FileUrlSignature = "sig",
+            AddressPosition = LetterAddressPosition.left,
+            AutoSend = false,
+            DeliveryProduct = "cheap",
+            PrintMode = LetterPrintMode.simplex,
+            PrintSpectrum = LetterPrintSpectrum.grayscale
+        }
+    };
+
+    private static DataPatch<LetterSend> CreateLetterSendPatch(string id) => new()
+    {
+        Id = id,
+        Type = PingenApiDataType.letters,
+        Attributes = new LetterSend
+        {
+            DeliveryProduct = "cheap",
+            PrintMode = LetterPrintMode.simplex,
+            PrintSpectrum = LetterPrintSpectrum.grayscale
+        }
+    };
+
+    private static DataPatch<LetterUpdate> CreateLetterUpdatePatch(string id) => new()
+    {
+        Id = id,
+        Type = PingenApiDataType.letters,
+        Attributes = new LetterUpdate
+        {
+            PaperTypes = ["normal"]
+        }
+    };
+
+    private static DataPost<LetterPriceConfiguration> CreateLetterPriceConfigurationPost() => new()
+    {
+        Type = PingenApiDataType.letters,
+        Attributes = new LetterPriceConfiguration
+        {
+            Country = "CH",
+            PaperTypes = ["normal"],
+            PrintMode = LetterPrintMode.simplex,
+            PrintSpectrum = LetterPrintSpectrum.grayscale,
+            DeliveryProduct = "cheap"
+        }
+    };
+
+    private static ApiError CreateApiError(string code, string detail) => new(
+    [
+        new ApiErrorData(code, "Error", detail, new ApiErrorSource(string.Empty, string.Empty))
+    ]);
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/OrganisationServiceTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/OrganisationServiceTests.cs
@@ -1,5 +1,7 @@
 using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Exceptions;
 using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.Relations;
@@ -105,6 +107,131 @@ public class OrganisationServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// Verifies GetPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetPage_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("server_error", "Service unavailable");
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<OrganisationData>>(
+                "organisations",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<OrganisationData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _organisationService.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies GetPage forwards the supplied paging request through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task GetPage_WithPagingRequest_ForwardsRequestToConnectionHandler()
+    {
+        var pagingRequest = new ApiPagingRequest { PageNumber = 3, PageLimit = 25 };
+
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<OrganisationData>>(
+                "organisations",
+                pagingRequest,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<OrganisationData>> { IsSuccess = true });
+
+        await _organisationService.GetPage(pagingRequest);
+
+        await _mockConnectionHandler.Received(1).GetAsync<CollectionResult<OrganisationData>>(
+            "organisations",
+            pagingRequest,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies GetPageResultsAsync surfaces an API failure as a <see cref="PingenApiErrorException"/>
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_ApiError_ThrowsPingenApiErrorException()
+    {
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<OrganisationData>>(
+                "organisations",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<OrganisationData>>
+            {
+                IsSuccess = false,
+                ApiError = CreateApiError("server_error", "boom")
+            });
+
+        await Should.ThrowAsync<PingenApiErrorException>(async () =>
+        {
+            await foreach (var _ in _organisationService.GetPageResultsAsync())
+            {
+                // consume pages
+            }
+        });
+    }
+
+    /// <summary>
+    /// Verifies Get propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Get_ApiError_ReturnsFailureResult()
+    {
+        const string organisationId = "missing-org";
+        var apiError = CreateApiError("not_found", "Organisation not found");
+        _mockConnectionHandler
+            .GetAsync<SingleResult<OrganisationDataDetailed>>(
+                $"organisations/{organisationId}",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<OrganisationDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _organisationService.Get(organisationId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies Get with an empty ID constructs an endpoint path with a trailing slash and does not throw
+    /// </summary>
+    [Test]
+    public async Task Get_EmptyId_ConstructsTrailingSlashPath()
+    {
+        _mockConnectionHandler
+            .GetAsync<SingleResult<OrganisationDataDetailed>>(
+                "organisations/",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<OrganisationDataDetailed>> { IsSuccess = true });
+
+        await _organisationService.Get(string.Empty);
+
+        await _mockConnectionHandler.Received(1).GetAsync<SingleResult<OrganisationDataDetailed>>(
+            "organisations/",
+            Arg.Any<ApiRequest?>(),
+            Arg.Any<CancellationToken>());
+    }
+
     private static OrganisationData CreateOrganisationData(string id) => new()
     {
         Id = id,
@@ -112,4 +239,9 @@ public class OrganisationServiceTests
         Attributes = new Organisation(null, null, null, null, null, null, null, null, null, null, null, null, null),
         Relationships = new OrganisationRelationships(new RelatedManyOutput(new RelatedManyLinks(new RelatedManyLinkInfo("", new RelatedManyLinkMeta(0)))))
     };
+
+    private static ApiError CreateApiError(string code, string detail) => new(
+    [
+        new ApiErrorData(code, "Error", detail, new ApiErrorSource(string.Empty, string.Empty))
+    ]);
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/UserServiceTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/UserServiceTests.cs
@@ -1,5 +1,7 @@
 using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Exceptions;
 using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.Relations;
@@ -103,6 +105,132 @@ public class UserServiceTests
         pages[0].First().Id.ShouldBe("assoc-1");
     }
 
+    /// <summary>
+    /// Verifies Get propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Get_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("unauthorized", "Token is invalid");
+        _mockConnectionHandler
+            .GetAsync<SingleResult<UserDataDetailed>>(
+                "user",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<UserDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _userService.Get();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies Get forwards the supplied API request through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task Get_WithApiRequest_ForwardsRequestToConnectionHandler()
+    {
+        var apiRequest = new ApiRequest { Include = ["associations"] };
+
+        _mockConnectionHandler
+            .GetAsync<SingleResult<UserDataDetailed>>(
+                "user",
+                apiRequest,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<UserDataDetailed>> { IsSuccess = true });
+
+        await _userService.Get(apiRequest);
+
+        await _mockConnectionHandler.Received(1).GetAsync<SingleResult<UserDataDetailed>>(
+            "user",
+            apiRequest,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies GetAssociationsPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetAssociationsPage_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("server_error", "Service unavailable");
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<UserAssociationDataDetailed>>(
+                "user/associations",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<UserAssociationDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _userService.GetAssociationsPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies GetAssociationsPage forwards the supplied paging request through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task GetAssociationsPage_WithPagingRequest_ForwardsRequestToConnectionHandler()
+    {
+        var pagingRequest = new ApiPagingRequest { PageNumber = 5, PageLimit = 10 };
+
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<UserAssociationDataDetailed>>(
+                "user/associations",
+                pagingRequest,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<UserAssociationDataDetailed>> { IsSuccess = true });
+
+        await _userService.GetAssociationsPage(pagingRequest);
+
+        await _mockConnectionHandler.Received(1).GetAsync<CollectionResult<UserAssociationDataDetailed>>(
+            "user/associations",
+            pagingRequest,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies GetAssociationsPageResultsAsync surfaces an API failure as a <see cref="PingenApiErrorException"/>
+    /// </summary>
+    [Test]
+    public async Task GetAssociationsPageResultsAsync_ApiError_ThrowsPingenApiErrorException()
+    {
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<UserAssociationDataDetailed>>(
+                "user/associations",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<UserAssociationDataDetailed>>
+            {
+                IsSuccess = false,
+                ApiError = CreateApiError("server_error", "boom")
+            });
+
+        await Should.ThrowAsync<PingenApiErrorException>(async () =>
+        {
+            await foreach (var _ in _userService.GetAssociationsPageResultsAsync())
+            {
+                // consume pages
+            }
+        });
+    }
+
     private static UserAssociationDataDetailed CreateUserAssociationDataDetailed(string id) => new()
     {
         Id = id,
@@ -111,4 +239,9 @@ public class UserServiceTests
         Relationships = new UserAssociationRelationships(new RelatedSingleOutput(new RelatedSingleLinks(""), new Abstractions.Models.Base.DataIdentity { Id = "", Type = PingenApiDataType.organisations })),
         Meta = new(new(new UserAssociationAbilities(PingenApiAbility.ok, PingenApiAbility.ok, PingenApiAbility.ok), new OrganisationAbilities(PingenApiAbility.ok)))
     };
+
+    private static ApiError CreateApiError(string code, string detail) => new(
+    [
+        new ApiErrorData(code, "Error", detail, new ApiErrorSource(string.Empty, string.Empty))
+    ]);
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/WebhookServiceTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/Connectors/WebhookServiceTests.cs
@@ -1,4 +1,5 @@
 using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Exceptions;
 using PingenApiNet.Abstractions.Models.Api;
 using PingenApiNet.Abstractions.Models.Api.Embedded;
 using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
@@ -169,6 +170,219 @@ public class WebhookServiceTests
         pages[0].First().Id.ShouldBe("webhook-page-1");
     }
 
+    /// <summary>
+    /// Verifies GetPage propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task GetPage_ApiError_ReturnsFailureResult()
+    {
+        var apiError = CreateApiError("server_error", "Service unavailable");
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<WebhookData>>(
+                "webhooks",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<WebhookData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _webhookService.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies GetPageResultsAsync surfaces an API failure as a <see cref="PingenApiErrorException"/>
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_ApiError_ThrowsPingenApiErrorException()
+    {
+        _mockConnectionHandler
+            .GetAsync<CollectionResult<WebhookData>>(
+                "webhooks",
+                Arg.Any<ApiPagingRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<CollectionResult<WebhookData>>
+            {
+                IsSuccess = false,
+                ApiError = CreateApiError("server_error", "boom")
+            });
+
+        await Should.ThrowAsync<PingenApiErrorException>(async () =>
+        {
+            await foreach (var _ in _webhookService.GetPageResultsAsync())
+            {
+                // consume pages
+            }
+        });
+    }
+
+    /// <summary>
+    /// Verifies Get propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Get_ApiError_ReturnsFailureResult()
+    {
+        const string webhookId = "missing-webhook";
+        var apiError = CreateApiError("not_found", "Webhook not found");
+        _mockConnectionHandler
+            .GetAsync<SingleResult<WebhookData>>(
+                $"webhooks/{webhookId}",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<WebhookData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _webhookService.Get(webhookId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies Get with an empty ID constructs an endpoint path with a trailing slash and does not throw
+    /// </summary>
+    [Test]
+    public async Task Get_EmptyId_ConstructsTrailingSlashPath()
+    {
+        _mockConnectionHandler
+            .GetAsync<SingleResult<WebhookData>>(
+                "webhooks/",
+                Arg.Any<ApiRequest?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<WebhookData>> { IsSuccess = true });
+
+        await _webhookService.Get(string.Empty);
+
+        await _mockConnectionHandler.Received(1).GetAsync<SingleResult<WebhookData>>(
+            "webhooks/",
+            Arg.Any<ApiRequest?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies Delete propagates failure ApiResult without throwing when the API returns an error
+    /// </summary>
+    [Test]
+    public async Task Delete_ApiError_ReturnsFailureResult()
+    {
+        const string webhookId = "delete-webhook";
+        var apiError = CreateApiError("conflict", "Webhook cannot be deleted");
+        _mockConnectionHandler
+            .DeleteAsync(
+                $"webhooks/{webhookId}",
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _webhookService.Delete(webhookId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError)
+        );
+    }
+
+    /// <summary>
+    /// Verifies Delete with an empty ID constructs an endpoint path with a trailing slash and does not throw
+    /// </summary>
+    [Test]
+    public async Task Delete_EmptyId_ConstructsTrailingSlashPath()
+    {
+        _mockConnectionHandler
+            .DeleteAsync(
+                "webhooks/",
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult { IsSuccess = true });
+
+        await _webhookService.Delete(string.Empty);
+
+        await _mockConnectionHandler.Received(1).DeleteAsync(
+            "webhooks/",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies Create propagates failure ApiResult without throwing when the API rejects the payload
+    /// </summary>
+    [Test]
+    public async Task Create_ApiError_ReturnsFailureResult()
+    {
+        var data = CreateWebhookPost();
+        var apiError = CreateApiError("unprocessable_entity", "Webhook URL is invalid");
+        _mockConnectionHandler
+            .PostAsync<SingleResult<WebhookData>, DataPost<WebhookCreate>>(
+                "webhooks",
+                Arg.Any<DataPost<WebhookCreate>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<WebhookData>>
+            {
+                IsSuccess = false,
+                ApiError = apiError
+            });
+
+        var result = await _webhookService.Create(data);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldBe(apiError),
+            () => result.Data.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies Create forwards the supplied idempotency key through to the connection handler
+    /// </summary>
+    [Test]
+    public async Task Create_WithIdempotencyKey_ForwardsKeyToConnectionHandler()
+    {
+        const string idempotencyKey = "webhook-idem-1";
+        var data = CreateWebhookPost();
+
+        _mockConnectionHandler
+            .PostAsync<SingleResult<WebhookData>, DataPost<WebhookCreate>>(
+                "webhooks",
+                Arg.Any<DataPost<WebhookCreate>>(),
+                idempotencyKey,
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResult<WebhookData>> { IsSuccess = true });
+
+        await _webhookService.Create(data, idempotencyKey);
+
+        await _mockConnectionHandler.Received(1).PostAsync<SingleResult<WebhookData>, DataPost<WebhookCreate>>(
+            "webhooks",
+            Arg.Any<DataPost<WebhookCreate>>(),
+            idempotencyKey,
+            Arg.Any<CancellationToken>());
+    }
+
+    private static DataPost<WebhookCreate> CreateWebhookPost() => new()
+    {
+        Type = PingenApiDataType.webhooks,
+        Attributes = new WebhookCreate
+        {
+            FileOriginalName = WebhookEventCategory.issues,
+            Url = new Uri("https://example.com/webhook"),
+            SigningKey = "test-signing-key"
+        }
+    };
+
     private static WebhookData CreateWebhookData(string id) => new()
     {
         Id = id,
@@ -176,4 +390,9 @@ public class WebhookServiceTests
         Attributes = new Webhook(WebhookEventCategory.issues, new Uri("https://example.com/webhook"), "key"),
         Relationships = new WebhookRelationships(new RelatedSingleOutput(new RelatedSingleLinks(""), new Abstractions.Models.Base.DataIdentity { Id = "", Type = PingenApiDataType.organisations }))
     };
+
+    private static ApiError CreateApiError(string code, string detail) => new(
+    [
+        new ApiErrorData(code, "Error", detail, new ApiErrorSource(string.Empty, string.Empty))
+    ]);
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Services/PingenConnectionHandlerTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/PingenConnectionHandlerTests.cs
@@ -536,9 +536,405 @@ public class PingenConnectionHandlerTests
         lastCapturedToken.ShouldBe("token-2");
     }
 
+    /// <summary>
+    /// Verifies that a freshly-issued access token whose lifetime is shorter than the 1-minute
+    /// safety buffer is treated as immediately expired by IsAuthorized() and rejected
+    /// at login with <see cref="InvalidOperationException"/> rather than being silently accepted
+    /// </summary>
+    [Test]
+    public async Task GetAsync_TokenWithLifetimeShorterThanBuffer_ThrowsInvalidOperationException()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "short-lived-token",
+            token_type = "Bearer",
+            expires_in = 30
+        });
+
+        var identityHandler = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandler = new MockHttpMessageHandler(HttpStatusCode.OK, "{\"data\":[]}");
+
+        var config = CreateConfig();
+        var httpClients = CreateHttpClients(identityHandler, apiHandler);
+        var handler = new PingenConnectionHandler(config, httpClients);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await handler.GetAsync("letters", (ApiPagingRequest?)null));
+        ex.Message.ShouldContain("Invalid access token object received");
+    }
+
+    /// <summary>
+    /// Verifies that after re-authentication caused by an expired token, subsequent requests
+    /// reuse the new long-lived token without triggering further authentication round-trips
+    /// </summary>
+    [Test]
+    public async Task GetAsync_AfterReAuthentication_NewTokenIsReusedForSubsequentRequests()
+    {
+        var authCallCount = 0;
+        var identityHandler = new MockHttpMessageHandler((_, _) =>
+        {
+            Interlocked.Increment(ref authCallCount);
+            var tokenJson = PingenSerialisationHelper.Serialize(new
+            {
+                access_token = $"token-{authCallCount}",
+                token_type = "Bearer",
+                expires_in = authCallCount == 1 ? 61 : 3600
+            });
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(tokenJson)
+            });
+        });
+
+        var capturedTokens = new List<string?>();
+        var apiHandler = new MockHttpMessageHandler((request, _) =>
+        {
+            capturedTokens.Add(request.Headers.Authorization?.Parameter);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":[]}")
+            });
+        });
+
+        var config = CreateConfig();
+        var httpClients = CreateHttpClients(identityHandler, apiHandler);
+        var handler = new PingenConnectionHandler(config, httpClients);
+
+        // First request authenticates with token-1 (expires_in=61, just > 60s buffer)
+        await handler.GetAsync("letters", (ApiPagingRequest?)null);
+
+        // Wait for token-1 to fall inside the 1-minute buffer, forcing re-authentication
+        await Task.Delay(2000);
+
+        // Second request triggers re-authentication and obtains token-2 (expires_in=3600)
+        await handler.GetAsync("letters", (ApiPagingRequest?)null);
+
+        // Third request must reuse the already-valid token-2 — no new authentication
+        await handler.GetAsync("letters", (ApiPagingRequest?)null);
+
+        authCallCount.ShouldBe(2);
+        capturedTokens.Count.ShouldBe(3);
+        capturedTokens[0].ShouldBe("token-1");
+        capturedTokens[1].ShouldBe("token-2");
+        capturedTokens[2].ShouldBe("token-2");
+    }
+
+    /// <summary>
+    /// Verifies that GetAsync throws <see cref="OperationCanceledException"/> when invoked with
+    /// a cancellation token that is already cancelled at the time of the API call
+    /// </summary>
+    [Test]
+    public async Task GetAsync_CancelledCancellationToken_ThrowsOperationCanceledException()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "test-token",
+            token_type = "Bearer",
+            expires_in = 3600
+        });
+
+        var identityHandler = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandler = new MockHttpMessageHandler((_, ct) =>
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":[]}")
+            });
+        });
+
+        var config = CreateConfig();
+        var httpClients = CreateHttpClients(identityHandler, apiHandler);
+        var handler = new PingenConnectionHandler(config, httpClients);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await handler.GetAsync("letters", (ApiPagingRequest?)null, cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that GetAsync throws <see cref="OperationCanceledException"/> when the cancellation
+    /// token is cancelled while the in-flight HTTP request is awaiting a response from the server
+    /// </summary>
+    [Test]
+    public async Task GetAsync_CancellationDuringInFlightRequest_ThrowsOperationCanceledException()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "test-token",
+            token_type = "Bearer",
+            expires_in = 3600
+        });
+
+        using var cts = new CancellationTokenSource();
+        var apiCallStarted = new ManualResetEventSlim(false);
+
+        var identityHandler = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandler = new MockHttpMessageHandler(async (_, ct) =>
+        {
+            apiCallStarted.Set();
+            await Task.Delay(Timeout.Infinite, ct);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":[]}")
+            };
+        });
+
+        var config = CreateConfig();
+        var httpClients = CreateHttpClients(identityHandler, apiHandler);
+        var handler = new PingenConnectionHandler(config, httpClients);
+
+        var requestTask = handler.GetAsync("letters", (ApiPagingRequest?)null, cts.Token);
+
+        apiCallStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () => await requestTask);
+    }
+
+    /// <summary>
+    /// Verifies that SendExternalRequestAsync throws <see cref="OperationCanceledException"/> when
+    /// invoked with a cancellation token that is already cancelled
+    /// </summary>
+    [Test]
+    public async Task SendExternalRequestAsync_CancelledCancellationToken_ThrowsOperationCanceledException()
+    {
+        var externalHandler = new MockHttpMessageHandler((_, ct) =>
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok")
+            });
+        });
+
+        var config = CreateConfig();
+        var httpClients = CreateHttpClients(externalHandler: externalHandler);
+        var handler = new PingenConnectionHandler(config, httpClients);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://external.example.com/file.pdf");
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await handler.SendExternalRequestAsync(request, cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that 429 Too Many Requests responses with no Retry-After header still surface as
+    /// failures and expose <c>null</c> as the RetryAfter value
+    /// </summary>
+    [Test]
+    public async Task GetAsync_RateLimitExceeded_WithoutRetryAfter_HasNullRetryAfter()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "test-token",
+            token_type = "Bearer",
+            expires_in = 3600
+        });
+
+        var identityHandler = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandler = new MockHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Content = new StringContent("{\"errors\":[{\"code\":\"429\",\"title\":\"Too Many Requests\",\"detail\":\"Rate limit exceeded\",\"source\":{\"pointer\":\"\",\"parameter\":\"\"}}]}")
+            };
+            response.Headers.Add("x-ratelimit-limit", "100");
+            response.Headers.Add("x-ratelimit-remaining", "0");
+            return Task.FromResult(response);
+        });
+
+        var config = CreateConfig();
+        var httpClients = CreateHttpClients(identityHandler, apiHandler);
+        var handler = new PingenConnectionHandler(config, httpClients);
+
+        var result = await handler.GetAsync("letters", (ApiPagingRequest?)null);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.RetryAfter.ShouldBeNull(),
+            () => result.RateLimitLimit.ShouldBe(100),
+            () => result.RateLimitRemaining.ShouldBe(0)
+        );
+    }
+
+    /// <summary>
+    /// Verifies that malformed (non-numeric) rate-limit headers are tolerated and silently
+    /// fall back to default values without throwing
+    /// </summary>
+    [Test]
+    public async Task GetAsync_MalformedRateLimitHeaders_DoesNotThrowAndUsesDefaults()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "test-token",
+            token_type = "Bearer",
+            expires_in = 3600
+        });
+
+        var identityHandler = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandler = new MockHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":[]}")
+            };
+            response.Headers.Add("x-ratelimit-limit", "not-a-number");
+            response.Headers.Add("x-ratelimit-remaining", "garbage");
+            response.Headers.Add("x-ratelimit-reset", "abc");
+            response.Headers.TryAddWithoutValidation("Retry-After", "soon");
+            return Task.FromResult(response);
+        });
+
+        var config = CreateConfig();
+        var httpClients = CreateHttpClients(identityHandler, apiHandler);
+        var handler = new PingenConnectionHandler(config, httpClients);
+
+        var result = await handler.GetAsync("letters", (ApiPagingRequest?)null);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.RateLimitLimit.ShouldBe(0),
+            () => result.RateLimitRemaining.ShouldBe(0),
+            () => result.RateLimitReset.ShouldBeNull(),
+            () => result.RetryAfter.ShouldBeNull()
+        );
+    }
+
+    /// <summary>
+    /// Verifies that two concurrent <see cref="PingenConnectionHandler"/> instances configured
+    /// with different organisation IDs build their request URLs against their own organisation
+    /// ID — confirming multi-tenant URL isolation under concurrency
+    /// </summary>
+    [Test]
+    public async Task ConcurrentRequests_DifferentOrganisationIds_UseDifferentUrlPaths()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "shared-token",
+            token_type = "Bearer",
+            expires_in = 3600
+        });
+
+        Uri? capturedUriA = null;
+        Uri? capturedUriB = null;
+
+        var identityHandlerA = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandlerA = new MockHttpMessageHandler((request, _) =>
+        {
+            capturedUriA = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":[]}")
+            });
+        });
+
+        var identityHandlerB = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandlerB = new MockHttpMessageHandler((request, _) =>
+        {
+            capturedUriB = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":[]}")
+            });
+        });
+
+        var configA = CreateConfig(defaultOrganisationId: "org-A");
+        var configB = CreateConfig(defaultOrganisationId: "org-B");
+
+        var handlerA = new PingenConnectionHandler(configA, CreateHttpClients(identityHandlerA, apiHandlerA));
+        var handlerB = new PingenConnectionHandler(configB, CreateHttpClients(identityHandlerB, apiHandlerB));
+
+        await Task.WhenAll(
+            handlerA.GetAsync("letters", (ApiPagingRequest?)null),
+            handlerB.GetAsync("letters", (ApiPagingRequest?)null));
+
+        capturedUriA.ShouldNotBeNull();
+        capturedUriB.ShouldNotBeNull();
+        capturedUriA!.AbsolutePath.ShouldBe("/organisations/org-A/letters");
+        capturedUriB!.AbsolutePath.ShouldBe("/organisations/org-B/letters");
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="PingenConnectionHandler.SetOrganisationId"/> between
+    /// requests routes subsequent calls under the new organisation ID in the URL path
+    /// </summary>
+    [Test]
+    public async Task SetOrganisationId_BetweenRequests_UsesNewOrganisationIdInUrlPath()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "test-token",
+            token_type = "Bearer",
+            expires_in = 3600
+        });
+
+        var capturedPaths = new List<string>();
+        var identityHandler = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandler = new MockHttpMessageHandler((request, _) =>
+        {
+            capturedPaths.Add(request.RequestUri!.AbsolutePath);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":[]}")
+            });
+        });
+
+        var config = CreateConfig(defaultOrganisationId: "initial-org");
+        var handler = new PingenConnectionHandler(config, CreateHttpClients(identityHandler, apiHandler));
+
+        await handler.GetAsync("letters", (ApiPagingRequest?)null);
+        handler.SetOrganisationId("new-org");
+        await handler.GetAsync("letters", (ApiPagingRequest?)null);
+
+        capturedPaths.Count.ShouldBe(2);
+        capturedPaths[0].ShouldBe("/organisations/initial-org/letters");
+        capturedPaths[1].ShouldBe("/organisations/new-org/letters");
+    }
+
+    /// <summary>
+    /// Verifies that requests against endpoints in NonOrganisationEndpoints (e.g. <c>user</c>)
+    /// do not have the organisation ID injected into their URL path
+    /// </summary>
+    [Test]
+    public async Task GetAsync_NonOrganisationEndpoint_DoesNotInjectOrganisationIdInPath()
+    {
+        var tokenJson = PingenSerialisationHelper.Serialize(new
+        {
+            access_token = "test-token",
+            token_type = "Bearer",
+            expires_in = 3600
+        });
+
+        Uri? capturedUri = null;
+        var identityHandler = new MockHttpMessageHandler(HttpStatusCode.OK, tokenJson);
+        var apiHandler = new MockHttpMessageHandler((request, _) =>
+        {
+            capturedUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\":{}}")
+            });
+        });
+
+        var config = CreateConfig(defaultOrganisationId: "some-org");
+        var handler = new PingenConnectionHandler(config, CreateHttpClients(identityHandler, apiHandler));
+
+        await handler.GetAsync("user", (ApiRequest?)null);
+
+        capturedUri.ShouldNotBeNull();
+        capturedUri!.AbsolutePath.ShouldBe("/user");
+    }
+
     private static IPingenConfiguration CreateConfig(
         string baseUri = "https://api.example.com/",
-        string identityUri = "https://identity.example.com/")
+        string identityUri = "https://identity.example.com/",
+        string defaultOrganisationId = "test-org-id")
     {
         return new PingenConfiguration
         {
@@ -546,7 +942,7 @@ public class PingenConnectionHandlerTests
             IdentityUri = identityUri,
             ClientId = "test-client-id",
             ClientSecret = "test-client-secret",
-            DefaultOrganisationId = "test-org-id"
+            DefaultOrganisationId = defaultOrganisationId
         };
     }
 


### PR DESCRIPTION
## Summary

Closes #84 — Wave 1 of the 100% test coverage roadmap (#82).

Expands unit tests in `PingenApiNet.UnitTests` for all 7 connector services and `PingenConnectionHandler` to cover error scenarios, edge cases, and argument validation. Test classes existed; this wave adds the missing paths.

| Phase | Files | Tests Added | Verdict |
|-------|-------|-------------|---------|
| Phase 1 | `BatchServiceTests`, `DistributionServiceTests`, `FilesServiceTests`, `LetterServiceTests` | +35 | ✅ APPROVED |
| Phase 2 | `OrganisationServiceTests`, `UserServiceTests`, `WebhookServiceTests`, `PingenConnectionHandlerTests` | +28 | ✅ APPROVED |

**Total:** 63 new unit tests — project now at 261 unit tests (baseline: 198), all passing.

## What was added

**Connector services (all 7):**
- Error response handling — every public method has an `_ApiError_*` test
- Argument validation — null/empty ID and null payload scenarios
- HTTP endpoint path verification per operation
- Query parameter serialization (auto-pagination error paths)

**`PingenConnectionHandlerTests`:**
- OAuth token expiry + refresh (short-lived token inside 1-minute safety buffer)
- 429 `Retry-After` header parsing and backoff (with and without header)
- Concurrent requests with separate organisation IDs (token isolation — no shared mutable state)
- Request cancellation via `CancellationToken` (pre-cancelled + in-flight)

## Test results

```
Passed! — Failed: 0, Passed: 261, Total: 261  (PingenApiNet.UnitTests.dll)
Passed! — Failed: 0, Passed: 35,  Total: 35   (PingenApiNet.Tests.Integration.dll)
```

Zero compiler warnings. No production source modified. E2E tests skipped (require staging credentials per CLAUDE.md).

## Verification

Both phases verified by the Docker verification agent:
- Build: 0 warnings, 0 errors
- All unit + integration tests pass
- Acceptance criteria met in full
- No production files modified
- Scope boundary respected (Phase 2 files untouched during Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)