### PR TITLE
test(integration): Wave 3 — cross-cutting integration tests for PingenConnectionHandler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ Offline unit tests that require no API credentials or network access. Uses **NUn
 Offline in-process integration tests using **NUnit 4 + Shouldly + WireMock.Net + Bogus**. Spins up a local WireMock HTTP server per test fixture, stubs both the Pingen API and the OAuth token endpoint, and exercises a real `PingenApiClient` wired to that server. Covers request/response round-trips, JSON:API envelope shaping, auto-pagination (`InScenario` state machines), and the three-HTTP-client routing (identity / api / external-files):
 
 - `BatchServiceTests`, `DistributionServiceTests`, `FilesServiceTests`, `LetterServiceTests`, `OrganisationServiceTests`, `PingenApiClientTests`, `UserServiceTests`, `WebhookServiceTests`.
+- `CrossCutting/` — `CancellationTokenTests`, `ConcurrencyTests`, `EdgeCaseTests`, `ErrorHandlingTests`, `PaginationTests`.
 - `IntegrationTestBase.cs` — handles `[OneTimeSetUp]` WireMock startup, per-test reset, token-endpoint stub, client construction, and disposal.
 - `Helpers/JsonApiStubHelper.cs` — low-level JSON:API envelope builder.
 - `Helpers/PingenResponseFactory.cs` — centralised WireMock JSON:API response builder using Bogus for realistic test data generation.

--- a/doc/ai-readiness.md
+++ b/doc/ai-readiness.md
@@ -106,10 +106,11 @@ dotnet test PingenApiNet.sln --collect:"XPlat Code Coverage"
 | DI (AspNetCore/PingenServiceCollectionTests.cs) | `AddPingenServices` registers all nine public interfaces. |
 | Webhooks (Webhooks.cs) | Offline deserialization of `Assets/webhook_sample.json` + `TryGetIncludedData` for Organisation / Letter / LetterEvent. |
 
-**`PingenApiNet.Tests.Integration`** (8 test files, all use real `PingenApiClient` + WireMock)
+**`PingenApiNet.Tests.Integration`** (13 test files, all use real `PingenApiClient` + WireMock)
 
 | Fixture | Coverage |
 |---|---|
+| `CrossCutting/*` | `CancellationTokenTests`, `ConcurrencyTests`, `ErrorHandlingTests`, `PaginationTests`, `EdgeCaseTests` covering API errors, auto-pagination boundaries, token cancellation, parallel requests, and JSON:API parsing edge cases. |
 | `PingenApiClientTests` | Facade-level: all connector properties are non-null; `SetOrganisationId` routes subsequent requests to the new org path. |
 | `LetterServiceTests` | `GetPage`, `GetPageResultsAsync` with two-page scenario, `Create`, `Send`, `Cancel`, `Get`, `Delete`, `Update`, `GetFileLocation` (302 + Location header), `DownloadFileContent` (external URL to WireMock), `CalculatePrice`, `GetEventsPage` + `GetEventsPageResultsAsync`, `GetIssuesPage` + `GetIssuesPageResultsAsync`. |
 | `WebhookServiceTests` | `GetPage`, paginated `GetPageResultsAsync`, `Create`, `Get`, `Delete`. |

--- a/doc/analysis/2026-04-20-test-coverage-roadmap.md
+++ b/doc/analysis/2026-04-20-test-coverage-roadmap.md
@@ -128,7 +128,9 @@
 
 ### Wave 3: Integration Tests — Cross-cutting Concerns
 
-**Scope:** `tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/` (new directory)
+**Phase 1 of 1 (Complete):** Create all 5 cross-cutting test classes.
+
+**Scope:** `tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/`
 
 New test classes:
 - `CancellationTokenTests` — `CancellationToken` propagation through HTTP pipeline

--- a/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/CancellationTokenTests.cs
+++ b/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/CancellationTokenTests.cs
@@ -1,0 +1,97 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using PingenApiNet.Abstractions.Models.Letters;
+using PingenApiNet.Tests.Integration.Helpers;
+
+namespace PingenApiNet.Tests.Integration.Tests.CrossCutting;
+
+/// <summary>
+///     Cross-cutting integration tests verifying <see cref="CancellationToken" /> propagation
+///     through <see cref="PingenConnectionHandler" />.
+/// </summary>
+[TestFixture]
+public sealed class CancellationTokenTests : IntegrationTestBase
+{
+    /// <summary>
+    ///     Verifies that an already-cancelled <see cref="CancellationToken" /> aborts the request
+    ///     without dispatching it to the API endpoint.
+    /// </summary>
+    [Test]
+    public async Task GetPage_WithCancelledToken_ShouldThrowAndNotSendRequest()
+    {
+        Server.StubJsonGet(OrgPath("batches"), PingenResponseFactory.BatchCollection());
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await Client.Batches.GetPage(cancellationToken: cts.Token));
+
+        Server.VerifyNotCalled(OrgPath("batches"));
+    }
+
+    /// <summary>
+    ///     Verifies that an already-cancelled <see cref="CancellationToken" /> aborts auto-pagination
+    ///     without dispatching any request to the API endpoint.
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_WithCancelledToken_ShouldThrowAndNotSendRequest()
+    {
+        Server.StubJsonGet(OrgPath("letters"), PingenResponseFactory.LetterCollection());
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (IEnumerable<LetterData> _ in
+                           Client.Letters.GetPageResultsAsync(cancellationToken: cts.Token))
+            {
+                // Should never iterate
+            }
+        });
+
+        Server.VerifyNotCalled(OrgPath("letters"));
+    }
+
+    /// <summary>
+    ///     Verifies that a single-item connector method (Get) also honours an already-cancelled token.
+    /// </summary>
+    [Test]
+    public async Task Get_WithCancelledToken_ShouldThrowAndNotSendRequest()
+    {
+        string batchId = Guid.NewGuid().ToString();
+        Server.StubJsonGet(OrgPath($"batches/{batchId}"), PingenResponseFactory.SingleBatch(batchId));
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await Client.Batches.Get(batchId, cancellationToken: cts.Token));
+
+        Server.VerifyNotCalled(OrgPath($"batches/{batchId}"));
+    }
+}

--- a/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/ConcurrencyTests.cs
+++ b/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/ConcurrencyTests.cs
@@ -1,0 +1,170 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Net.Http.Headers;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Batches;
+using PingenApiNet.Services.Connectors;
+using PingenApiNet.Tests.Integration.Helpers;
+
+namespace PingenApiNet.Tests.Integration.Tests.CrossCutting;
+
+/// <summary>
+///     Cross-cutting integration tests verifying concurrent request safety and per-handler
+///     token isolation when multiple <see cref="PingenApiClient" /> instances target distinct
+///     organisations against a shared WireMock server.
+/// </summary>
+[TestFixture]
+public sealed class ConcurrencyTests : IntegrationTestBase
+{
+    /// <summary>
+    ///     Dispose any HttpClient instances created by <see cref="CreateClient" /> after each test.
+    /// </summary>
+    [TearDown]
+    public void TearDownClients()
+    {
+        foreach (HttpClient c in _ownedClients) c.Dispose();
+
+        _ownedClients.Clear();
+    }
+
+    private readonly List<HttpClient> _ownedClients = [];
+
+    /// <summary>
+    ///     Verifies that two clients with different organisation IDs can run requests in parallel
+    ///     and each receive the data scoped to their own organisation, without token cross-contamination.
+    /// </summary>
+    [Test]
+    public async Task MultipleClients_DifferentOrganisations_ShouldIsolateRequests()
+    {
+        const string orgA = "org-A";
+        const string orgB = "org-B";
+
+        Server.StubJsonGet($"/organisations/{orgA}/batches",
+            PingenResponseFactory.BatchCollection(2, orgA));
+        Server.StubJsonGet($"/organisations/{orgB}/batches",
+            PingenResponseFactory.BatchCollection(5, orgB));
+
+        IPingenApiClient clientA = CreateClient(orgA);
+        IPingenApiClient clientB = CreateClient(orgB);
+
+        Task<ApiResult<CollectionResult<BatchData>>> resultATask = clientA.Batches.GetPage();
+        Task<ApiResult<CollectionResult<BatchData>>> resultBTask = clientB.Batches.GetPage();
+
+        await Task.WhenAll(resultATask, resultBTask);
+
+        ApiResult<CollectionResult<BatchData>> resultA = await resultATask;
+        ApiResult<CollectionResult<BatchData>> resultB = await resultBTask;
+
+        resultA.ShouldSatisfyAllConditions(
+            () => resultA.IsSuccess.ShouldBeTrue(),
+            () => resultA.Data.ShouldNotBeNull(),
+            () => resultA.Data!.Data.Count.ShouldBe(2));
+
+        resultB.ShouldSatisfyAllConditions(
+            () => resultB.IsSuccess.ShouldBeTrue(),
+            () => resultB.Data.ShouldNotBeNull(),
+            () => resultB.Data!.Data.Count.ShouldBe(5));
+
+        Server.VerifyCalled($"/organisations/{orgA}/batches");
+        Server.VerifyCalled($"/organisations/{orgB}/batches");
+    }
+
+    /// <summary>
+    ///     Verifies that many parallel requests against the same client all complete successfully,
+    ///     exercising the authentication semaphore's double-check guard for concurrent first-request
+    ///     authentication.
+    /// </summary>
+    [Test]
+    public async Task SingleClient_ManyParallelRequests_ShouldAllSucceed()
+    {
+        IPingenApiClient freshClient = CreateClient(TestOrganisationId);
+
+        Server.StubJsonGet(OrgPath("batches"), PingenResponseFactory.BatchCollection(1));
+
+        Task<ApiResult<CollectionResult<BatchData>>>[] tasks = Enumerable.Range(0, 10)
+            .Select(_ => freshClient.Batches.GetPage())
+            .ToArray();
+
+        ApiResult<CollectionResult<BatchData>>[] results = await Task.WhenAll(tasks);
+
+        results.Length.ShouldBe(10);
+        foreach (ApiResult<CollectionResult<BatchData>> r in results)
+        {
+            r.IsSuccess.ShouldBeTrue();
+            r.Data.ShouldNotBeNull();
+        }
+
+        Server.VerifyCalledAtLeastOnce(OrgPath("batches"));
+    }
+
+    /// <summary>
+    ///     Build a fresh <see cref="PingenApiClient" /> wired to the shared WireMock server with
+    ///     its own isolated set of <see cref="HttpClient" /> instances and an explicit organisation ID.
+    /// </summary>
+    private IPingenApiClient CreateClient(string organisationId)
+    {
+        string url = Server.Url!;
+
+        var identityClient = new HttpClient { BaseAddress = new Uri(url) };
+        identityClient.DefaultRequestHeaders.Accept.Clear();
+        identityClient.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/x-www-form-urlencoded"));
+
+        var apiClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            BaseAddress = new Uri(url)
+        };
+
+        var externalClient = new HttpClient { BaseAddress = new Uri(url) };
+
+        _ownedClients.Add(identityClient);
+        _ownedClients.Add(apiClient);
+        _ownedClients.Add(externalClient);
+
+        var configuration = new PingenConfiguration
+        {
+            BaseUri = "https://api.test.pingen.com/",
+            IdentityUri = "https://identity.test.pingen.com/",
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            DefaultOrganisationId = organisationId
+        };
+
+        var httpClients = new PingenHttpClients(identityClient, apiClient, externalClient);
+        var connectionHandler = new PingenConnectionHandler(configuration, httpClients);
+
+        return new PingenApiClient(
+            connectionHandler,
+            new LetterService(connectionHandler),
+            new BatchService(connectionHandler),
+            new UserService(connectionHandler),
+            new OrganisationService(connectionHandler),
+            new WebhookService(connectionHandler),
+            new FilesService(connectionHandler),
+            new DistributionService(connectionHandler));
+    }
+}

--- a/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/EdgeCaseTests.cs
+++ b/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/EdgeCaseTests.cs
@@ -1,0 +1,246 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Batches;
+using PingenApiNet.Abstractions.Models.Letters;
+using PingenApiNet.Abstractions.Models.Organisations;
+using PingenApiNet.Tests.Integration.Helpers;
+
+namespace PingenApiNet.Tests.Integration.Tests.CrossCutting;
+
+/// <summary>
+///     Cross-cutting integration tests verifying deserialization behavior on sparse, complex,
+///     or unusually large JSON:API responses.
+/// </summary>
+[TestFixture]
+public sealed class EdgeCaseTests : IntegrationTestBase
+{
+    /// <summary>
+    ///     Verifies that an empty <c>data: []</c> payload deserialises to an empty list rather
+    ///     than null, so callers can iterate without null guards.
+    /// </summary>
+    [Test]
+    public async Task GetPage_EmptyCollection_ShouldReturnEmptyList()
+    {
+        Server.StubJsonGet(OrgPath("batches"),
+            PingenResponseFactory.BatchCollection(0));
+
+        ApiResult<CollectionResult<BatchData>> result = await Client.Batches.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.Data.ShouldNotBeNull(),
+            () => result.Data!.Data.ShouldNotBeNull(),
+            () => result.Data!.Data.ShouldBeEmpty());
+    }
+
+    /// <summary>
+    ///     Verifies that a single resource with all-null optional attribute fields deserialises
+    ///     without throwing, so sparse fieldset responses are tolerated.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAllNullOptionalFields_ShouldDeserializeSuccessfully()
+    {
+        string batchId = Guid.NewGuid().ToString();
+        string body = JsonSerializer.Serialize(new
+        {
+            data = new
+            {
+                id = batchId,
+                type = "batches",
+                attributes =
+                    new
+                    {
+                        name = (string?)null,
+                        icon = (string?)null,
+                        status = (string?)null,
+                        file_original_name = (string?)null,
+                        letter_count = (int?)null,
+                        address_position = (string?)null,
+                        print_mode = (string?)null,
+                        print_spectrum = (string?)null,
+                        price_currency = (string?)null,
+                        price_value = (double?)null,
+                        submitted_at = (string?)null,
+                        created_at = (string?)null,
+                        updated_at = (string?)null
+                    },
+                relationships =
+                    new
+                    {
+                        organisation = JsonApiStubHelper.RelatedSingle(TestOrganisationId, "organisations"),
+                        events = JsonApiStubHelper.RelatedMany()
+                    },
+                meta = JsonApiStubHelper.MetaWithAbilities(new
+                {
+                    cancel = "ok",
+                    delete = "ok",
+                    submit = "ok",
+                    edit = "ok",
+                    change_window_position = "ok",
+                    add_attachment = "ok"
+                })
+            }
+        });
+
+        Server.StubJsonGet(OrgPath($"batches/{batchId}"), body);
+
+        ApiResult<SingleResult<BatchDataDetailed>> result = await Client.Batches.Get(batchId);
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.Data.ShouldNotBeNull(),
+            () => result.Data!.Data.Id.ShouldBe(batchId),
+            () => result.Data!.Data.Attributes.Name.ShouldBeNull(),
+            () => result.Data!.Data.Attributes.Status.ShouldBeNull(),
+            () => result.Data!.Data.Attributes.LetterCount.ShouldBeNull());
+    }
+
+    /// <summary>
+    ///     Verifies that a JSON:API response containing an <c>included</c> array is deserialised
+    ///     into <see cref="CollectionResult{T}.Included" /> with the included items accessible via
+    ///     <c>OfType&lt;T&gt;</c>.
+    /// </summary>
+    [Test]
+    public async Task GetPage_WithIncludedArray_ShouldDeserializeIncluded()
+    {
+        string orgId = TestOrganisationId;
+        string letterId = Guid.NewGuid().ToString();
+
+        string body = JsonSerializer.Serialize(new
+        {
+            data =
+                new[]
+                {
+                    new
+                    {
+                        id = letterId,
+                        type = "letters",
+                        attributes =
+                            new { status = "valid", file_original_name = "test.pdf", file_pages = 1 },
+                        relationships =
+                            new
+                            {
+                                organisation = JsonApiStubHelper.RelatedSingle(orgId, "organisations"),
+                                events = JsonApiStubHelper.RelatedMany()
+                            }
+                    }
+                },
+            included = new object[]
+            {
+                new
+                {
+                    id = orgId,
+                    type = "organisations",
+                    attributes =
+                        new
+                        {
+                            name = "Included Org",
+                            status = "active",
+                            plan = "professional",
+                            billing_mode = "prepaid",
+                            billing_currency = "CHF",
+                            billing_balance = 100.0,
+                            default_country = "CH"
+                        }
+                }
+            },
+            links = new
+            {
+                first = "https://api.test.pingen.com/?page[number]=1",
+                last = "https://api.test.pingen.com/?page[number]=1",
+                prev = (string?)null,
+                next = (string?)null,
+                self = "https://api.test.pingen.com/?page[number]=1"
+            },
+            meta = new
+            {
+                current_page = 1,
+                last_page = 1,
+                per_page = 20,
+                from = 1,
+                to = 1,
+                total = 1
+            }
+        });
+
+        Server.StubJsonGet(OrgPath("letters"), body);
+
+        ApiResult<CollectionResult<LetterData>> result = await Client.Letters.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.Data.ShouldNotBeNull(),
+            () => result.Data!.Included.ShouldNotBeNull(),
+            () => result.Data!.Included!.Count.ShouldBe(1));
+
+        var includedOrgs = result.Data!.Included!.OfType<Organisation>().ToList();
+        includedOrgs.Count.ShouldBe(1);
+        includedOrgs[0].Id.ShouldBe(orgId);
+        includedOrgs[0].Attributes.Name.ShouldBe("Included Org");
+    }
+
+    /// <summary>
+    ///     Verifies that a large page (100 items) deserialises every item without truncation.
+    /// </summary>
+    [Test]
+    public async Task GetPage_With100Items_ShouldDeserializeAll()
+    {
+        const int itemCount = 100;
+
+        Server.StubJsonGet(OrgPath("batches"),
+            PingenResponseFactory.BatchCollection(itemCount));
+
+        ApiResult<CollectionResult<BatchData>> result = await Client.Batches.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.Data.ShouldNotBeNull(),
+            () => result.Data!.Data.Count.ShouldBe(itemCount));
+
+        result.Data!.Data.Select(d => d.Id).Distinct().Count().ShouldBe(itemCount);
+    }
+
+    /// <summary>
+    ///     Verifies that a response with a missing <c>included</c> key (not just null) deserialises
+    ///     successfully and surfaces the included collection as null on the result.
+    /// </summary>
+    [Test]
+    public async Task GetPage_WithoutIncludedKey_ShouldHaveNullIncluded()
+    {
+        Server.StubJsonGet(OrgPath("batches"),
+            PingenResponseFactory.BatchCollection(2));
+
+        ApiResult<CollectionResult<BatchData>> result = await Client.Batches.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeTrue(),
+            () => result.Data.ShouldNotBeNull(),
+            () => result.Data!.Included.ShouldBeNull());
+    }
+}

--- a/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/ErrorHandlingTests.cs
+++ b/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/ErrorHandlingTests.cs
@@ -1,0 +1,166 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using PingenApiNet.Abstractions.Exceptions;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Batches;
+using PingenApiNet.Abstractions.Models.Letters;
+using PingenApiNet.Tests.Integration.Helpers;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace PingenApiNet.Tests.Integration.Tests.CrossCutting;
+
+/// <summary>
+///     Cross-cutting integration tests verifying that HTTP error status codes returned by the
+///     Pingen API are translated into the correct exception types and that the JSON:API error
+///     envelope is parsed into <see cref="ApiResult.ApiError" />.
+/// </summary>
+[TestFixture]
+public sealed class ErrorHandlingTests : IntegrationTestBase
+{
+    /// <summary>
+    ///     Verifies that auto-pagination across the letters endpoint surfaces a
+    ///     <see cref="PingenApiErrorException" /> for every documented HTTP error status code.
+    /// </summary>
+    /// <param name="statusCode">HTTP status code returned by the stub.</param>
+    [TestCase(401)]
+    [TestCase(403)]
+    [TestCase(404)]
+    [TestCase(422)]
+    [TestCase(500)]
+    [TestCase(502)]
+    [TestCase(503)]
+    [TestCase(504)]
+    public async Task GetPageResultsAsync_OnApiError_ShouldThrowPingenApiErrorException(int statusCode)
+    {
+        Server.StubError(
+            OrgPath("letters"),
+            "GET",
+            PingenResponseFactory.ErrorResponse(
+                $"Error {statusCode}",
+                $"HTTP {statusCode} returned by stub",
+                statusCode.ToString()),
+            statusCode);
+
+        PingenApiErrorException exception = await Should.ThrowAsync<PingenApiErrorException>(async () =>
+        {
+            await foreach (IEnumerable<LetterData> _ in Client.Letters.GetPageResultsAsync())
+            {
+                // Should never iterate
+            }
+        });
+
+        exception.ApiResult.ShouldNotBeNull();
+        exception.ApiResult!.IsSuccess.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     Verifies that the JSON:API error envelope is deserialized into
+    ///     <see cref="ApiResult.ApiError" /> with title and detail fields preserved.
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_OnApiError_ShouldParseJsonApiErrorEnvelope()
+    {
+        Server.StubError(
+            OrgPath("letters"),
+            "GET",
+            PingenResponseFactory.ErrorResponse(
+                "Validation failed",
+                "The request payload is invalid"));
+
+        PingenApiErrorException exception = await Should.ThrowAsync<PingenApiErrorException>(async () =>
+        {
+            await foreach (IEnumerable<LetterData> _ in Client.Letters.GetPageResultsAsync())
+            {
+                // Should never iterate
+            }
+        });
+
+        exception.ApiResult.ShouldNotBeNull();
+        exception.ApiResult!.ApiError.ShouldNotBeNull();
+        exception.ApiResult.ApiError!.Errors.Count.ShouldBeGreaterThan(0);
+        exception.ApiResult.ApiError.Errors[0].Title.ShouldBe("Validation failed");
+        exception.ApiResult.ApiError.Errors[0].Detail.ShouldBe("The request payload is invalid");
+    }
+
+    /// <summary>
+    ///     Verifies that a single GET returning an HTTP error sets <see cref="ApiResult.IsSuccess" />
+    ///     to false without throwing, since callers can opt to handle the raw <see cref="ApiResult" />.
+    /// </summary>
+    [TestCase(401)]
+    [TestCase(403)]
+    [TestCase(404)]
+    [TestCase(422)]
+    [TestCase(500)]
+    [TestCase(502)]
+    [TestCase(503)]
+    [TestCase(504)]
+    public async Task GetPage_OnApiError_ShouldReturnUnsuccessfulApiResult(int statusCode)
+    {
+        Server.StubError(
+            OrgPath("batches"),
+            "GET",
+            PingenResponseFactory.ErrorResponse(status: statusCode.ToString()),
+            statusCode);
+
+        ApiResult<CollectionResult<BatchData>> result = await Client.Batches.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.ApiError.ShouldNotBeNull(),
+            () => result.ApiError!.Errors.Count.ShouldBeGreaterThan(0),
+            () => result.Data.ShouldBeNull());
+    }
+
+    /// <summary>
+    ///     Verifies that a 429 Too Many Requests response surfaces the rate-limit
+    ///     <see cref="ApiResult.RetryAfter" /> header alongside the failure indication.
+    /// </summary>
+    [Test]
+    public async Task GetPage_On429TooManyRequests_ShouldExposeRetryAfter()
+    {
+        Server
+            .Given(Request.Create()
+                .WithPath(OrgPath("batches"))
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(429)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("Retry-After", "30")
+                .WithBody(PingenResponseFactory.ErrorResponse(
+                    "Too Many Requests",
+                    "Rate limit exceeded",
+                    "429")));
+
+        ApiResult<CollectionResult<BatchData>> result = await Client.Batches.GetPage();
+
+        result.ShouldSatisfyAllConditions(
+            () => result.IsSuccess.ShouldBeFalse(),
+            () => result.RetryAfter.ShouldBe(30),
+            () => result.ApiError.ShouldNotBeNull());
+    }
+}

--- a/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/PaginationTests.cs
+++ b/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/PaginationTests.cs
@@ -1,0 +1,212 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Letters;
+using PingenApiNet.Tests.Integration.Helpers;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace PingenApiNet.Tests.Integration.Tests.CrossCutting;
+
+/// <summary>
+///     Cross-cutting integration tests verifying boundary conditions for the
+///     <c>IAsyncEnumerable</c> auto-pagination implemented by
+///     <c>ConnectorService.AutoPage</c> and surfaced via
+///     <c>GetPageResultsAsync</c>.
+/// </summary>
+[TestFixture]
+public sealed class PaginationTests : IntegrationTestBase
+{
+    /// <summary>
+    ///     Verifies that an empty first page (count=0, currentPage=1, lastPage=1) yields no items
+    ///     and triggers exactly one API call.
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_EmptyFirstPage_ShouldYieldNoItemsAndStopAfterOneCall()
+    {
+        Server.StubJsonGet(
+            OrgPath("letters"),
+            PingenResponseFactory.LetterCollection(0, currentPage: 1, lastPage: 1));
+
+        var allItems = new List<LetterData>();
+        await foreach (IEnumerable<LetterData> page in Client.Letters.GetPageResultsAsync()) allItems.AddRange(page);
+
+        allItems.ShouldBeEmpty();
+        Server.VerifyCalled(OrgPath("letters"));
+    }
+
+    /// <summary>
+    ///     Verifies that a single populated page (count=3, currentPage=1, lastPage=1) yields all
+    ///     items and triggers exactly one API call.
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_SinglePage_ShouldYieldAllItemsAndStopAfterOneCall()
+    {
+        Server.StubJsonGet(
+            OrgPath("letters"),
+            PingenResponseFactory.LetterCollection());
+
+        var allItems = new List<LetterData>();
+        await foreach (IEnumerable<LetterData> page in Client.Letters.GetPageResultsAsync()) allItems.AddRange(page);
+
+        allItems.Count.ShouldBe(3);
+        Server.VerifyCalled(OrgPath("letters"));
+    }
+
+    /// <summary>
+    ///     Verifies that across three pages the auto-pager fetches every page until
+    ///     <c>currentPage &gt;= lastPage</c>, yielding the union of all items.
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_MultiPage_ShouldFetchAllPages()
+    {
+        const string scenario = "letters-multi-page";
+
+        Server
+            .Given(Request.Create().WithPath(OrgPath("letters")).UsingGet())
+            .InScenario(scenario)
+            .WillSetStateTo("page2")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString())
+                .WithBody(PingenResponseFactory.LetterCollection(2, currentPage: 1, lastPage: 3)));
+
+        Server
+            .Given(Request.Create().WithPath(OrgPath("letters")).UsingGet())
+            .InScenario(scenario)
+            .WhenStateIs("page2")
+            .WillSetStateTo("page3")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString())
+                .WithBody(PingenResponseFactory.LetterCollection(2, currentPage: 2, lastPage: 3)));
+
+        Server
+            .Given(Request.Create().WithPath(OrgPath("letters")).UsingGet())
+            .InScenario(scenario)
+            .WhenStateIs("page3")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString())
+                .WithBody(PingenResponseFactory.LetterCollection(1, currentPage: 3, lastPage: 3)));
+
+        var allItems = new List<LetterData>();
+        int pageCount = 0;
+        await foreach (IEnumerable<LetterData> page in Client.Letters.GetPageResultsAsync())
+        {
+            pageCount++;
+            allItems.AddRange(page);
+        }
+
+        pageCount.ShouldBe(3);
+        allItems.Count.ShouldBe(5);
+        Server.VerifyCalled(OrgPath("letters"), times: 3);
+    }
+
+    /// <summary>
+    ///     Verifies that when the last page returns exactly the per-page limit of items, the
+    ///     auto-pager stops cleanly without requesting a phantom <c>N+1</c> page.
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_LastPageBoundary_ShouldNotRequestExtraPage()
+    {
+        const string scenario = "letters-boundary";
+        const int perPage = 5;
+
+        Server
+            .Given(Request.Create().WithPath(OrgPath("letters")).UsingGet())
+            .InScenario(scenario)
+            .WillSetStateTo("page2")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString())
+                .WithBody(PingenResponseFactory.LetterCollection(
+                    perPage,
+                    currentPage: 1,
+                    lastPage: 2)));
+
+        Server
+            .Given(Request.Create().WithPath(OrgPath("letters")).UsingGet())
+            .InScenario(scenario)
+            .WhenStateIs("page2")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString())
+                .WithBody(PingenResponseFactory.LetterCollection(
+                    perPage,
+                    currentPage: 2,
+                    lastPage: 2)));
+
+        var allItems = new List<LetterData>();
+        await foreach (IEnumerable<LetterData> page in Client.Letters.GetPageResultsAsync()) allItems.AddRange(page);
+
+        allItems.Count.ShouldBe(perPage * 2);
+        Server.VerifyCalled(OrgPath("letters"), times: 2);
+    }
+
+    /// <summary>
+    ///     Verifies that auto-pagination starts from a non-default initial page number
+    ///     and continues until <c>lastPage</c>.
+    /// </summary>
+    [Test]
+    public async Task GetPageResultsAsync_StartingFromMiddlePage_ShouldFetchRemainingPages()
+    {
+        const string scenario = "letters-from-middle";
+
+        Server
+            .Given(Request.Create().WithPath(OrgPath("letters")).UsingGet())
+            .InScenario(scenario)
+            .WillSetStateTo("nextPage")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString())
+                .WithBody(PingenResponseFactory.LetterCollection(2, currentPage: 2, lastPage: 3)));
+
+        Server
+            .Given(Request.Create().WithPath(OrgPath("letters")).UsingGet())
+            .InScenario(scenario)
+            .WhenStateIs("nextPage")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString())
+                .WithBody(PingenResponseFactory.LetterCollection(2, currentPage: 3, lastPage: 3)));
+
+        var apiPagingRequest = new ApiPagingRequest { PageNumber = 2 };
+        var allItems = new List<LetterData>();
+        await foreach (IEnumerable<LetterData> page in Client.Letters.GetPageResultsAsync(apiPagingRequest))
+            allItems.AddRange(page);
+
+        allItems.Count.ShouldBe(4);
+        Server.VerifyCalled(OrgPath("letters"), times: 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Creates 5 new cross-cutting integration test classes under `tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/`
- 33 new tests covering `PingenConnectionHandler` HTTP infrastructure independently of any connector service
- Uses Wave 0 helpers (`PingenResponseFactory`, `WireMockExtensions`) and WireMock stubs throughout — no real HTTP calls

## New Test Classes

| Class | Tests | Covers |
|---|---|---|
| `CancellationTokenTests` | 3 | Token propagation; `VerifyNotCalled` confirms no HTTP dispatch after cancel |
| `ConcurrencyTests` | 2 | Parallel requests; auth-semaphore isolation; two clients with different `OrganisationId` |
| `ErrorHandlingTests` | 18 | 401/403/404/422/500/502/503/504 → `PingenApiErrorException`; JSON:API error envelope; 429 `Retry-After` |
| `PaginationTests` | 5 | `GetPageResultsAsync` empty/single/multi-page/exact-boundary/mid-start |
| `EdgeCaseTests` | 5 | Empty collection, null optional fields, `included` array, 100+ item page |

## Test Results

```
Passed! — Failed: 0, Passed: 33, Skipped: 0 — CrossCutting filter
Passed! — Failed: 0, Passed: 68, Skipped: 0 — Full integration suite
Passed! — Failed: 0, Passed: 666, Skipped: 0 — Unit tests
```

## Verification

Verification agent: **VERDICT: APPROVED** — all acceptance criteria met, zero ReSharper findings on new files, no regressions.

## Documentation

- `doc/analysis/2026-04-20-test-coverage-roadmap.md` — Wave 3 marked complete
- `doc/ai-readiness.md` — test count updated, CrossCutting fixture row added
- `CLAUDE.md` — Integration Tests section updated

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)