### PR TITLE
Wave 6: E2E tests — services group 1 (Batch, Organisation, User, Webhook)

### DIFF
--- a/doc/analysis/2026-04-20-test-coverage-roadmap.md
+++ b/doc/analysis/2026-04-20-test-coverage-roadmap.md
@@ -33,7 +33,7 @@
 |---|---|
 | Unit | Test classes exist for all 7 services + helpers; error/edge cases covered for Batch, Distribution, Files, and Letter services (Wave 1 Phase 1 complete) |
 | Integration | Test classes exist for all 7 services; cross-cutting scenarios complete (Wave 3); 100% coverage for Batch, Distribution, Files, Webhook (Wave 4 complete) |
-| E2E | Only 4 scenarios: Distribution, FileUpload, LettersGetAll, RateLimit |
+| E2E | Batch, Organisation, User, Webhook covered (Wave 6 complete); other scenarios: Distribution, FileUpload, LettersGetAll, RateLimit |
 
 ### Stack Alignment (vs CashCtrlApiNet reference)
 | Library | Status |
@@ -181,6 +181,8 @@ New test classes:
 ---
 
 ### Wave 6: E2E Tests — Services Group 1
+
+**Phase 1 of 1 (Complete):** Batch, Organisation, User, Webhook.
 
 **Scope:** `tests/PingenApiNet.Tests.E2E/` — Batch, Organisation, User, Webhook
 

--- a/tests/PingenApiNet.Tests.E2E/Batch/BatchE2eTests.cs
+++ b/tests/PingenApiNet.Tests.E2E/Batch/BatchE2eTests.cs
@@ -1,0 +1,140 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Enums.Batches;
+using PingenApiNet.Abstractions.Enums.Letters;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Batches;
+using PingenApiNet.Abstractions.Models.Batches.Views;
+using PingenApiNet.Abstractions.Models.Files;
+
+namespace PingenApiNet.Tests.E2E.Batch;
+
+/// <summary>
+///     End-to-end tests for the Pingen batches endpoint. Exercises the 3-step batch creation
+///     flow (file upload → batch create), single-resource lookup, and paginated listing
+///     against the live staging API.
+/// </summary>
+[TestFixture]
+[Category("E2e")]
+public sealed class BatchE2eTests : E2eTestBase
+{
+    private const string SampleFileName = "sample.pdf";
+
+    private string? _createdBatchId;
+
+    /// <summary>
+    ///     Creates a new batch by first uploading a sample PDF and then posting the batch payload.
+    ///     The created id is shared with subsequent ordered tests for downstream lookups.
+    /// </summary>
+    [Test]
+    [Order(1)]
+    public async Task Create_ShouldCreateBatch()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        ApiResult<SingleResult<FileUploadData>> uploadPath =
+            await PingenApiClient!.Files.GetPath();
+        AssertSuccess(uploadPath);
+
+        await using var stream = new MemoryStream();
+        await using (FileStream fileStream = File.OpenRead($"Assets/{SampleFileName}"))
+        {
+            await fileStream.CopyToAsync(stream);
+        }
+
+        ExternalRequestResult uploadResult = await PingenApiClient.Files.UploadFile(uploadPath.Data!.Data, stream);
+        uploadResult.IsSuccess.ShouldBeTrue();
+
+        var data = new DataPost<BatchCreate, BatchCreateRelationships>
+        {
+            Type = PingenApiDataType.batches,
+            Attributes = new BatchCreate
+            {
+                Name = $"{TestPrefix}-batch",
+                Icon = BatchIcon.document,
+                FileOriginalName = SampleFileName,
+                FileUrl = uploadPath.Data.Data.Attributes.Url,
+                FileUrlSignature = uploadPath.Data.Data.Attributes.UrlSignature,
+                AddressPosition = LetterAddressPosition.left,
+                GroupingType = BatchGroupingType.zip,
+                GroupingOptionsSplitType = BatchGroupingOptionsSplitType.file
+            },
+            Relationships = BatchCreateRelationships.Create("1234567890")
+        };
+
+        ApiResult<SingleResult<BatchDataDetailed>> result = await PingenApiClient.Batches.Create(data);
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldNotBeNullOrEmpty();
+        result.Data.Data.Attributes.Name.ShouldBe($"{TestPrefix}-batch");
+
+        _createdBatchId = result.Data.Data.Id;
+
+        // IBatchService does not expose a Delete operation, so cleanup is recorded for tracking
+        // and registers a no-op so the LIFO queue still reflects the creation.
+        RegisterCleanup(() => Task.CompletedTask);
+    }
+
+    /// <summary>
+    ///     Verifies that the batch created by <see cref="Create_ShouldCreateBatch" /> can be fetched by id.
+    /// </summary>
+    [Test]
+    [Order(2)]
+    public async Task Get_ShouldReturnBatchById()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _createdBatchId.ShouldNotBeNullOrEmpty();
+
+        ApiResult<SingleResult<BatchDataDetailed>> result = await PingenApiClient!.Batches.Get(_createdBatchId!);
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldBe(_createdBatchId);
+        result.Data.Data.Attributes.Name.ShouldBe($"{TestPrefix}-batch");
+    }
+
+    /// <summary>
+    ///     Verifies that a paginated list of batches can be retrieved and exposes pagination meta.
+    /// </summary>
+    [Test]
+    [Order(3)]
+    public async Task GetPage_ShouldReturnPaginatedBatches()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        ApiResult<CollectionResult<BatchData>> result =
+            await PingenApiClient!.Batches.GetPage(new ApiPagingRequest { PageNumber = 1, PageLimit = 20 });
+
+        AssertSuccess(result);
+        result.Data!.Data.ShouldNotBeNull();
+        result.Data.Meta.CurrentPage.ShouldNotBeNull();
+        result.Data.Meta.CurrentPage!.Value.ShouldBeGreaterThanOrEqualTo(1);
+        result.Data.Meta.LastPage.ShouldNotBeNull();
+        result.Data.Meta.LastPage!.Value.ShouldBeGreaterThanOrEqualTo(1);
+    }
+}

--- a/tests/PingenApiNet.Tests.E2E/Organisations/OrganisationE2eTests.cs
+++ b/tests/PingenApiNet.Tests.E2E/Organisations/OrganisationE2eTests.cs
@@ -1,0 +1,78 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Organisations;
+
+namespace PingenApiNet.Tests.E2E.Organisations;
+
+/// <summary>
+///     End-to-end tests for the Pingen organisations endpoint. Exercises a paginated list
+///     and a single-resource lookup against the live staging API.
+/// </summary>
+[TestFixture]
+[Category("E2e")]
+public sealed class OrganisationE2eTests : E2eTestBase
+{
+    /// <summary>
+    ///     Verifies that a paginated list of organisations can be retrieved and exposes pagination meta.
+    /// </summary>
+    [Test]
+    public async Task GetPage_ShouldReturnPaginatedOrganisations()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        ApiResult<CollectionResult<OrganisationData>> result =
+            await PingenApiClient!.Organisations.GetPage(new ApiPagingRequest { PageNumber = 1, PageLimit = 20 });
+
+        AssertSuccess(result);
+        result.Data!.Data.ShouldNotBeNull();
+        result.Data.Meta.CurrentPage.ShouldNotBeNull();
+        result.Data.Meta.CurrentPage!.Value.ShouldBeGreaterThanOrEqualTo(1);
+        result.Data.Meta.LastPage.ShouldNotBeNull();
+        result.Data.Meta.LastPage!.Value.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    /// <summary>
+    ///     Verifies that the configured default organisation can be fetched by id.
+    /// </summary>
+    [Test]
+    public async Task Get_ShouldReturnOrganisationById()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        string organisationId =
+            Environment.GetEnvironmentVariable("PingenApiNet__OrganisationId") ??
+            throw new InvalidOperationException("Missing PingenApiNet__OrganisationId");
+
+        ApiResult<SingleResult<OrganisationDataDetailed>> result =
+            await PingenApiClient!.Organisations.Get(organisationId);
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldBe(organisationId);
+        result.Data.Data.Attributes.Name.ShouldNotBeNullOrEmpty();
+    }
+}

--- a/tests/PingenApiNet.Tests.E2E/Users/UserE2eTests.cs
+++ b/tests/PingenApiNet.Tests.E2E/Users/UserE2eTests.cs
@@ -1,0 +1,76 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.UserAssociations;
+using PingenApiNet.Abstractions.Models.Users;
+
+namespace PingenApiNet.Tests.E2E.Users;
+
+/// <summary>
+///     End-to-end tests for the Pingen user endpoint. Exercises a paginated association
+///     list and a single-resource lookup of the authenticated user against the live staging API.
+/// </summary>
+[TestFixture]
+[Category("E2e")]
+public sealed class UserE2eTests : E2eTestBase
+{
+    /// <summary>
+    ///     Verifies that a paginated list of user associations can be retrieved and exposes pagination meta.
+    /// </summary>
+    [Test]
+    public async Task GetAssociationsPage_ShouldReturnPaginatedAssociations()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        ApiResult<CollectionResult<UserAssociationDataDetailed>> result =
+            await PingenApiClient!.Users.GetAssociationsPage(
+                new ApiPagingRequest { PageNumber = 1, PageLimit = 20 });
+
+        AssertSuccess(result);
+        result.Data!.Data.ShouldNotBeNull();
+        result.Data.Meta.CurrentPage.ShouldNotBeNull();
+        result.Data.Meta.CurrentPage!.Value.ShouldBeGreaterThanOrEqualTo(1);
+        result.Data.Meta.LastPage.ShouldNotBeNull();
+        result.Data.Meta.LastPage!.Value.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    /// <summary>
+    ///     Verifies that the authenticated user can be fetched and that core attributes are populated.
+    ///     The Pingen user endpoint identifies the user from the bearer token rather than a path id.
+    /// </summary>
+    [Test]
+    public async Task Get_ShouldReturnAuthenticatedUserById()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        ApiResult<SingleResult<UserDataDetailed>> result = await PingenApiClient!.Users.Get();
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldNotBeNullOrEmpty();
+        result.Data.Data.Attributes.Email.ShouldNotBeNullOrEmpty();
+    }
+}

--- a/tests/PingenApiNet.Tests.E2E/Webhooks/WebhookE2eTests.cs
+++ b/tests/PingenApiNet.Tests.E2E/Webhooks/WebhookE2eTests.cs
@@ -1,0 +1,226 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Webhooks;
+using PingenApiNet.Abstractions.Models.Webhooks.Views;
+using PingenApiNet.Services.Connectors;
+
+namespace PingenApiNet.Tests.E2E.Webhooks;
+
+/// <summary>
+///     End-to-end tests for the Pingen webhooks endpoint. Exercises create, get, list,
+///     and delete operations against the live staging API. Orphan webhooks from crashed
+///     prior runs are scavenged once before the fixture starts so they cannot pollute
+///     state across runs.
+/// </summary>
+[TestFixture]
+[Category("E2e")]
+public sealed class WebhookE2eTests : E2eTestBase
+{
+    private const string TestPrefixIdentifier = "PG-E2E-";
+
+    private string? _createdWebhookId;
+
+    /// <summary>
+    ///     Removes any webhook tagged with <see cref="TestPrefixIdentifier" /> that was left behind
+    ///     by a crashed previous run. Runs once before the fixture begins; constructs its own
+    ///     client because the base class only sets <see cref="E2eTestBase.PingenApiClient" /> in
+    ///     the per-test <c>[SetUp]</c> hook.
+    /// </summary>
+    [OneTimeSetUp]
+    public async Task ScavengeOrphansBeforeRunning()
+    {
+        IPingenApiClient bootstrapClient = BuildBootstrapClient();
+        await ScavengeWebhookOrphans(bootstrapClient);
+    }
+
+    /// <summary>
+    ///     Creates a new webhook tagged with <see cref="E2eTestBase.TestPrefix" /> in the URL,
+    ///     remembers its id for downstream tests, and registers an idempotent delete in the
+    ///     LIFO cleanup queue.
+    /// </summary>
+    [Test]
+    [Order(1)]
+    public async Task Create_ShouldCreateWebhook()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        var data = new DataPost<WebhookCreate>
+        {
+            Type = PingenApiDataType.webhooks,
+            Attributes = new WebhookCreate
+            {
+                FileOriginalName = WebhookEventCategory.issues,
+                Url = new Uri($"https://example.com/{TestPrefix}/webhook"),
+                SigningKey = Guid.NewGuid().ToString("N")
+            }
+        };
+
+        ApiResult<SingleResult<WebhookData>> result = await PingenApiClient!.Webhooks.Create(data);
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldNotBeNullOrEmpty();
+        result.Data.Data.Attributes.Url.ShouldNotBeNull();
+        result.Data.Data.Attributes.Url!.ToString().ShouldContain(TestPrefix);
+
+        _createdWebhookId = result.Data.Data.Id;
+
+        string idForCleanup = _createdWebhookId;
+        RegisterCleanup(async () =>
+        {
+            try
+            {
+                await PingenApiClient!.Webhooks.Delete(idForCleanup);
+            }
+            catch (Exception)
+            {
+                // Cleanup is best-effort: the explicit Delete in test Order(4) may have already removed it.
+            }
+        });
+    }
+
+    /// <summary>
+    ///     Verifies that the webhook created in <see cref="Create_ShouldCreateWebhook" /> can be fetched by id.
+    /// </summary>
+    [Test]
+    [Order(2)]
+    public async Task Get_ShouldReturnWebhookById()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _createdWebhookId.ShouldNotBeNullOrEmpty();
+
+        ApiResult<SingleResult<WebhookData>> result = await PingenApiClient!.Webhooks.Get(_createdWebhookId!);
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldBe(_createdWebhookId);
+        result.Data.Data.Attributes.Url.ShouldNotBeNull();
+        result.Data.Data.Attributes.Url!.ToString().ShouldContain(TestPrefix);
+    }
+
+    /// <summary>
+    ///     Verifies that paginated webhook listing surfaces the webhook created in
+    ///     <see cref="Create_ShouldCreateWebhook" />.
+    /// </summary>
+    [Test]
+    [Order(3)]
+    public async Task GetPage_ShouldReturnWebhooks_IncludingCreated()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _createdWebhookId.ShouldNotBeNullOrEmpty();
+
+        var allItems = new List<WebhookData>();
+        await foreach (IEnumerable<WebhookData> page in PingenApiClient!.Webhooks.GetPageResultsAsync())
+            allItems.AddRange(page);
+
+        allItems.ShouldNotBeEmpty();
+        allItems.ShouldContain(item => item.Id == _createdWebhookId);
+    }
+
+    /// <summary>
+    ///     Explicitly deletes the webhook created in <see cref="Create_ShouldCreateWebhook" /> before
+    ///     the LIFO cleanup queue runs. This proves the live Delete path independently of teardown.
+    /// </summary>
+    [Test]
+    [Order(4)]
+    public async Task Delete_ShouldRemoveWebhook()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _createdWebhookId.ShouldNotBeNullOrEmpty();
+
+        ApiResult result = await PingenApiClient!.Webhooks.Delete(_createdWebhookId!);
+
+        AssertSuccess(result);
+    }
+
+    /// <summary>
+    ///     End-of-fixture sweep that catches any webhook still tagged with
+    ///     <see cref="TestPrefixIdentifier" /> after the LIFO queue has run.
+    /// </summary>
+    protected override async Task ScavengeOrphans()
+    {
+        if (PingenApiClient is not null)
+            await ScavengeWebhookOrphans(PingenApiClient);
+    }
+
+    private static async Task ScavengeWebhookOrphans(IPingenApiClient client)
+    {
+        var orphanIds = new List<string>();
+        await foreach (IEnumerable<WebhookData> page in client.Webhooks.GetPageResultsAsync())
+        foreach (WebhookData webhook in page)
+        {
+            string url = webhook.Attributes.Url?.ToString() ?? string.Empty;
+            if (url.Contains(TestPrefixIdentifier))
+                orphanIds.Add(webhook.Id);
+        }
+
+        foreach (string id in orphanIds)
+            try
+            {
+                await client.Webhooks.Delete(id);
+            }
+            catch (Exception)
+            {
+                // Best-effort cleanup: do not fail the fixture if a single orphan cannot be deleted.
+            }
+    }
+
+    private static PingenApiClient BuildBootstrapClient()
+    {
+        var configuration = new PingenConfiguration
+        {
+            BaseUri =
+                Environment.GetEnvironmentVariable("PingenApiNet__BaseUri") ??
+                throw new InvalidOperationException("Missing PingenApiNet__BaseUri"),
+            IdentityUri =
+                Environment.GetEnvironmentVariable("PingenApiNet__IdentityUri") ??
+                throw new InvalidOperationException("Missing PingenApiNet__IdentityUri"),
+            ClientId =
+                Environment.GetEnvironmentVariable("PingenApiNet__ClientId") ??
+                throw new InvalidOperationException("Missing PingenApiNet__ClientId"),
+            ClientSecret =
+                Environment.GetEnvironmentVariable("PingenApiNet__ClientSecret") ??
+                throw new InvalidOperationException("Missing PingenApiNet__ClientSecret"),
+            DefaultOrganisationId =
+                Environment.GetEnvironmentVariable("PingenApiNet__OrganisationId") ??
+                throw new InvalidOperationException("Missing PingenApiNet__OrganisationId")
+        };
+
+        var connectionHandler = new PingenConnectionHandler(configuration, PingenHttpClients.Create(configuration));
+
+        return new PingenApiClient(
+            connectionHandler,
+            new LetterService(connectionHandler),
+            new BatchService(connectionHandler),
+            new UserService(connectionHandler),
+            new OrganisationService(connectionHandler),
+            new WebhookService(connectionHandler),
+            new FilesService(connectionHandler),
+            new DistributionService(connectionHandler));
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #89 — Wave 6 of the 100% test coverage roadmap (#82).

Creates 4 new E2E test fixtures against the real Pingen staging API:

| Fixture | File | Tests |
|---------|------|-------|
| `BatchE2eTests` | `Batch/BatchE2eTests.cs` | Create batch, Get by ID, Paginated list |
| `OrganisationE2eTests` | `Organisations/OrganisationE2eTests.cs` | List (paginated), Get by ID |
| `UserE2eTests` | `Users/UserE2eTests.cs` | List (paginated), Get by ID |
| `WebhookE2eTests` | `Webhooks/WebhookE2eTests.cs` | Full CRUD (Create, Get, List, Delete) + orphan scavenging |

All fixtures:
- Inherit `E2eTestBase` (Wave 0)
- Use `"PG-E2E-{guid}"` isolation prefix
- Register resources in LIFO cleanup queue via `RegisterCleanup()`

## Phase Outcomes

**Phase 1 of 1** — Create 4 E2E test fixtures
- Worker: ✅ Implemented all 4 fixtures; correctly resolved architect blueprint enum errors (`BatchIcon.document`, `BatchGroupingType.zip`, `WebhookEventCategory.issues`) against actual source enums
- Verification: ✅ APPROVED — build clean (0 warnings), 816 existing tests pass, 11 new E2E tests discovered under `Category=E2e`
- Doc-writer: ✅ Updated `doc/analysis/2026-04-20-test-coverage-roadmap.md` to mark Wave 6 complete

## Notable decisions

- `IBatchService` exposes no `Delete` endpoint — batch cleanup registered as `Task.CompletedTask` placeholder with documented rationale
- Webhook `Order(4)` explicitly deletes the created webhook; the registered LIFO cleanup handles the resulting 404 gracefully (best-effort try/catch)
- Orphan scavenging on `WebhookE2eTests` cleans leftover `"PG-E2E-"` webhooks from crashed prior runs

Closes #89