### PR TITLE
Wave 7: E2E tests — Letter workflow, Distribution, Files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ PingenApiNet__ClientSecret
 PingenApiNet__OrganisationId
 ```
 
-E2E tests inherit from `E2eTestBase.cs` which provides a LIFO cleanup queue (`RegisterCleanup(Func<Task>)`), orphan scavenging pattern, isolation prefix (`TestPrefix`), and standard `AssertSuccess` overloads. Current fixtures: `DistributionGetDeliveryProducts`, `FileUpload`, `LettersGetAll`, `RateLimit` (the last one deliberately exceeds rate limits to validate `Retry-After` behavior — run sparingly).
+E2E tests inherit from `E2eTestBase.cs` which provides a LIFO cleanup queue (`RegisterCleanup(Func<Task>)`), orphan scavenging pattern, isolation prefix (`TestPrefix`), and standard `AssertSuccess` overloads. Current fixtures cover Batches, Distributions, Files, Letters (including `LetterWorkflowE2eTests` for full state transitions), Organisations, Users, Webhooks, and `RateLimit` (the last one deliberately exceeds rate limits to validate `Retry-After` behavior — run sparingly).
 
 ## Known Constraints and Gotchas
 

--- a/doc/analysis/2026-04-20-test-coverage-roadmap.md
+++ b/doc/analysis/2026-04-20-test-coverage-roadmap.md
@@ -202,6 +202,8 @@ New/updated test fixtures inheriting `E2eTestBase`:
 
 ### Wave 7: E2E Tests — Services Group 2
 
+**Phase 1 of 1 (Complete):** Letter workflow, Distribution, Files.
+
 **Scope:** `tests/PingenApiNet.Tests.E2E/` — Letter workflow, Distribution, Files
 
 - Create `LetterWorkflowE2eTests` — full live scenario: upload file → create letter → send → cancel

--- a/tests/PingenApiNet.Tests.E2E/Letters/LetterWorkflowE2eTests.cs
+++ b/tests/PingenApiNet.Tests.E2E/Letters/LetterWorkflowE2eTests.cs
@@ -1,0 +1,352 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Net;
+using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Enums.Letters;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Files;
+using PingenApiNet.Abstractions.Models.Letters;
+using PingenApiNet.Abstractions.Models.Letters.Embedded;
+using PingenApiNet.Abstractions.Models.Letters.Views;
+using PingenApiNet.Services.Connectors;
+
+namespace PingenApiNet.Tests.E2E.Letters;
+
+/// <summary>
+///     End-to-end tests for the full Pingen letter workflow. Uploads a sample PDF, creates a
+///     letter that references the upload, polls for the letter to reach the <c>valid</c> state,
+///     submits it via the send endpoint, and (when the API still allows it) cancels the letter.
+///     Orphan letters left behind by crashed prior runs are scavenged once before the fixture
+///     starts so they cannot pollute state across runs.
+/// </summary>
+[TestFixture]
+[Category("E2e")]
+public sealed class LetterWorkflowE2eTests : E2eTestBase
+{
+    /// <summary>
+    ///     Removes any letter tagged with <see cref="TestPrefixIdentifier" /> in its file name that
+    ///     was left behind by a crashed previous run. Runs once before the fixture begins; constructs
+    ///     its own client because the base class only sets <see cref="E2eTestBase.PingenApiClient" />
+    ///     in the per-test <c>[SetUp]</c> hook.
+    /// </summary>
+    [OneTimeSetUp]
+    public async Task ScavengeOrphansBeforeRunning()
+    {
+        IPingenApiClient bootstrapClient = BuildBootstrapClient();
+        await ScavengeLetterOrphans(bootstrapClient);
+    }
+
+    private const string SampleFileName = "sample.pdf";
+    private const string TestPrefixIdentifier = "PG-E2E-";
+    private const int ValidationPollAttempts = 120;
+    private const int ValidationPollDelaySeconds = 1;
+
+    private FileUploadData? _uploadData;
+    private string? _createdLetterId;
+
+    /// <summary>
+    ///     Uploads the local sample PDF using the path returned by <c>Files.GetPath</c>. The resulting
+    ///     <see cref="FileUploadData" /> is shared with subsequent ordered tests. Files are immutable on
+    ///     the Pingen storage layer, so no cleanup is registered for the upload itself.
+    /// </summary>
+    [Test]
+    [Order(1)]
+    public async Task UploadFile_ShouldUploadPdf()
+    {
+        PingenApiClient.ShouldNotBeNull();
+
+        ApiResult<SingleResult<FileUploadData>> uploadPath = await PingenApiClient!.Files.GetPath();
+        AssertSuccess(uploadPath);
+
+        await using var stream = new MemoryStream();
+        await using (FileStream fileStream = File.OpenRead($"Assets/{SampleFileName}"))
+        {
+            await fileStream.CopyToAsync(stream);
+        }
+
+        ExternalRequestResult uploadResult = await PingenApiClient.Files.UploadFile(uploadPath.Data!.Data, stream);
+
+        uploadResult.ShouldSatisfyAllConditions(
+            () => uploadResult.IsSuccess.ShouldBeTrue(),
+            () => uploadResult.StatusCode.ShouldBe(HttpStatusCode.OK)
+        );
+
+        _uploadData = uploadPath.Data.Data;
+    }
+
+    /// <summary>
+    ///     Creates a letter that references the uploaded file with <c>auto_send=false</c>. The
+    ///     recipient and file name are tagged with <see cref="E2eTestBase.TestPrefix" /> so orphans
+    ///     can be identified later. A best-effort cleanup is registered to cancel or delete the
+    ///     letter at fixture teardown.
+    /// </summary>
+    [Test]
+    [Order(2)]
+    public async Task Create_ShouldCreateLetterInDraft()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _uploadData.ShouldNotBeNull();
+
+        var metaData = new LetterMetaData
+        {
+            Recipient = new LetterMetaDataContact
+            {
+                Name = $"{TestPrefix}-recipient",
+                Street = "Teststrasse",
+                Number = "1",
+                Zip = "3303",
+                City = "Jegenstorf",
+                Country = "CH"
+            },
+            Sender = new LetterMetaDataContact
+            {
+                Name = $"{TestPrefix}-sender",
+                Street = "Musterstrasse",
+                Number = "2",
+                Zip = "1212",
+                City = "Musterhausen",
+                Country = "CH"
+            }
+        };
+
+        var data = new DataPost<LetterCreate, LetterCreateRelationships>
+        {
+            Type = PingenApiDataType.letters,
+            Attributes = new LetterCreate
+            {
+                FileOriginalName = $"{TestPrefix}-{SampleFileName}",
+                FileUrl = _uploadData!.Attributes.Url,
+                FileUrlSignature = _uploadData.Attributes.UrlSignature,
+                AddressPosition = LetterAddressPosition.left,
+                AutoSend = false,
+                DeliveryProduct = LetterCreateDeliveryProduct.Cheap,
+                PrintMode = LetterPrintMode.simplex,
+                PrintSpectrum = LetterPrintSpectrum.grayscale,
+                MetaData = metaData
+            },
+            Relationships = LetterCreateRelationships.Create("1234567890")
+        };
+
+        ApiResult<SingleResult<LetterDataDetailed>> result = await PingenApiClient!.Letters.Create(data);
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldNotBeNullOrEmpty();
+        result.Data.Data.Attributes.FileOriginalName.ShouldNotBeNull();
+        result.Data.Data.Attributes.FileOriginalName!.ShouldContain(TestPrefix);
+
+        _createdLetterId = result.Data.Data.Id;
+
+        string idForCleanup = _createdLetterId;
+        RegisterCleanup(async () => await TryCleanupLetter(PingenApiClient!, idForCleanup));
+    }
+
+    /// <summary>
+    ///     Polls <c>Letters.Get</c> until the letter created by <see cref="Create_ShouldCreateLetterInDraft" />
+    ///     reaches the <see cref="LetterStates.Valid" /> state. Pingen runs PDF validation asynchronously,
+    ///     so this waits for the terminal validation state before downstream tests can send the letter.
+    /// </summary>
+    [Test]
+    [Order(3)]
+    public async Task Get_ShouldShowLetterValidAfterPolling()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _createdLetterId.ShouldNotBeNullOrEmpty();
+
+        LetterDataDetailed? letter = null;
+        for (int attempt = 1; attempt <= ValidationPollAttempts; attempt++)
+        {
+            ApiResult<SingleResult<LetterDataDetailed>> getResult =
+                await PingenApiClient!.Letters.Get(_createdLetterId!);
+
+            if (getResult.IsSuccess && getResult.Data?.Data is { } current)
+            {
+                string? status = current.Attributes.Status;
+                if (status is LetterStates.Valid or LetterStates.Invalid or LetterStates.Unprintable)
+                {
+                    letter = current;
+                    break;
+                }
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(ValidationPollDelaySeconds));
+        }
+
+        letter.ShouldNotBeNull();
+        letter.Attributes.Status.ShouldBe(LetterStates.Valid);
+    }
+
+    /// <summary>
+    ///     Submits the validated letter via <c>Letters.Send</c> with a Swiss <c>postag_b</c> product and
+    ///     verifies that the resulting status is no longer <see cref="LetterStates.Valid" />, proving
+    ///     the state machine moved forward. Concrete next states (sending, submitted, processing, sent)
+    ///     are timing-dependent on the staging API, so the assertion only checks that progress was made.
+    /// </summary>
+    [Test]
+    [Order(4)]
+    public async Task Send_ShouldTransitionLetterBeyondValid()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _createdLetterId.ShouldNotBeNullOrEmpty();
+
+        var sendData = new DataPatch<LetterSend>
+        {
+            Id = _createdLetterId!,
+            Type = PingenApiDataType.letters,
+            Attributes = new LetterSend
+            {
+                DeliveryProduct = LetterSendDeliveryProduct.PostAgB,
+                PrintMode = LetterPrintMode.simplex,
+                PrintSpectrum = LetterPrintSpectrum.grayscale
+            }
+        };
+
+        ApiResult<SingleResult<LetterDataDetailed>> result = await PingenApiClient!.Letters.Send(sendData);
+
+        AssertSuccess(result);
+        result.Data!.Data.Id.ShouldBe(_createdLetterId);
+        result.Data.Data.Attributes.Status.ShouldNotBe(LetterStates.Valid);
+    }
+
+    /// <summary>
+    ///     Cancels the letter when the API reports cancel as <see cref="PingenApiAbility.ok" />. Once a
+    ///     letter has progressed too far in the pipeline the cancel ability disappears; in that case the
+    ///     test is skipped so the fixture remains green even on fast staging environments. The LIFO
+    ///     cleanup queue still removes the letter at teardown.
+    /// </summary>
+    [Test]
+    [Order(5)]
+    public async Task Cancel_ShouldCancelLetterIfStillAllowed()
+    {
+        PingenApiClient.ShouldNotBeNull();
+        _createdLetterId.ShouldNotBeNullOrEmpty();
+
+        ApiResult<SingleResult<LetterDataDetailed>> current =
+            await PingenApiClient!.Letters.Get(_createdLetterId!);
+        AssertSuccess(current);
+
+        PingenApiAbility cancelAbility = current.Data!.Data.Meta.Abilities.Self.Cancel;
+        if (cancelAbility is not PingenApiAbility.ok)
+        {
+            Assert.Pass($"Cancel not currently allowed (ability={cancelAbility}). Cleanup queue will handle removal.");
+            return;
+        }
+
+        ApiResult cancelResult = await PingenApiClient.Letters.Cancel(_createdLetterId!);
+        AssertSuccess(cancelResult);
+    }
+
+    /// <summary>
+    ///     End-of-fixture sweep that catches any letter still tagged with
+    ///     <see cref="TestPrefixIdentifier" /> after the LIFO queue has run.
+    /// </summary>
+    protected override async Task ScavengeOrphans()
+    {
+        if (PingenApiClient is not null)
+            await ScavengeLetterOrphans(PingenApiClient);
+    }
+
+    private static async Task ScavengeLetterOrphans(IPingenApiClient client)
+    {
+        // Walk recent pages only — a full org-wide sweep is too expensive on staging.
+        const int maxPagesToScan = 5;
+        var orphanIds = new List<string>();
+        int pagesScanned = 0;
+
+        await foreach (IEnumerable<LetterData> page in client.Letters.GetPageResultsAsync())
+        {
+            pagesScanned++;
+            foreach (LetterData letter in page)
+            {
+                string fileOriginalName = letter.Attributes.FileOriginalName ?? string.Empty;
+                string address = letter.Attributes.Address ?? string.Empty;
+                if (fileOriginalName.Contains(TestPrefixIdentifier) || address.Contains(TestPrefixIdentifier))
+                    orphanIds.Add(letter.Id);
+            }
+
+            if (pagesScanned >= maxPagesToScan)
+                break;
+        }
+
+        foreach (string id in orphanIds)
+            await TryCleanupLetter(client, id);
+    }
+
+    private static async Task TryCleanupLetter(IPingenApiClient client, string letterId)
+    {
+        try
+        {
+            ApiResult<SingleResult<LetterDataDetailed>> current = await client.Letters.Get(letterId);
+            if (!current.IsSuccess || current.Data?.Data is not { } detail)
+                return;
+
+            LetterAbilities abilities = detail.Meta.Abilities.Self;
+            if (abilities.Cancel is PingenApiAbility.ok)
+                await client.Letters.Cancel(letterId);
+            else if (abilities.Delete is PingenApiAbility.ok)
+                await client.Letters.Delete(letterId);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup: a single orphan that resists removal must not fail the fixture.
+        }
+    }
+
+    private static PingenApiClient BuildBootstrapClient()
+    {
+        var configuration = new PingenConfiguration
+        {
+            BaseUri =
+                Environment.GetEnvironmentVariable("PingenApiNet__BaseUri") ??
+                throw new InvalidOperationException("Missing PingenApiNet__BaseUri"),
+            IdentityUri =
+                Environment.GetEnvironmentVariable("PingenApiNet__IdentityUri") ??
+                throw new InvalidOperationException("Missing PingenApiNet__IdentityUri"),
+            ClientId =
+                Environment.GetEnvironmentVariable("PingenApiNet__ClientId") ??
+                throw new InvalidOperationException("Missing PingenApiNet__ClientId"),
+            ClientSecret =
+                Environment.GetEnvironmentVariable("PingenApiNet__ClientSecret") ??
+                throw new InvalidOperationException("Missing PingenApiNet__ClientSecret"),
+            DefaultOrganisationId =
+                Environment.GetEnvironmentVariable("PingenApiNet__OrganisationId") ??
+                throw new InvalidOperationException("Missing PingenApiNet__OrganisationId")
+        };
+
+        var connectionHandler = new PingenConnectionHandler(configuration, PingenHttpClients.Create(configuration));
+
+        return new PingenApiClient(
+            connectionHandler,
+            new LetterService(connectionHandler),
+            new BatchService(connectionHandler),
+            new UserService(connectionHandler),
+            new OrganisationService(connectionHandler),
+            new WebhookService(connectionHandler),
+            new FilesService(connectionHandler),
+            new DistributionService(connectionHandler));
+    }
+}

--- a/tests/PingenApiNet.Tests.E2E/Tests/DistributionGetDeliveryProducts.cs
+++ b/tests/PingenApiNet.Tests.E2E/Tests/DistributionGetDeliveryProducts.cs
@@ -28,58 +28,67 @@ using PingenApiNet.Abstractions.Exceptions;
 using PingenApiNet.Abstractions.Helpers;
 using PingenApiNet.Abstractions.Models.Api;
 using PingenApiNet.Abstractions.Models.Api.Embedded;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
 using PingenApiNet.Abstractions.Models.DeliveryProducts;
 
 namespace PingenApiNet.Tests.E2E.Tests;
 
 /// <summary>
-///
+///     End-to-end tests for the Pingen distributions endpoint. Exercises the delivery-products
+///     listing — both single-page retrieval and the auto-paginated <c>IAsyncEnumerable</c> path —
+///     against the live staging API. Sorting and filtering parameters are sent and accepted by the
+///     server, but the upstream endpoint is documented to ignore them, so this fixture verifies
+///     the request shape and pagination contract rather than filter semantics.
 /// </summary>
-public class DistributionGetDeliveryProducts : E2eTestBase
+[TestFixture]
+[Category("E2e")]
+public sealed class DistributionGetDeliveryProducts : E2eTestBase
 {
     /// <summary>
-    ///
+    ///     Verifies that delivery products can be retrieved both via a single page request and via
+    ///     the auto-paginated <c>IAsyncEnumerable</c> helper. A non-empty product set across all
+    ///     pages confirms the server returned valid data and that auto-pagination terminates.
     /// </summary>
     [Test]
     public async Task GetProducts()
     {
-        // TODO: This tests the serialization of api paging request. It seems to be fine and is accepted by the pingen API, but the distribution products endpoint seems not to support sorting and filtering...
+        // The distributions/delivery-products endpoint accepts sorting and filtering parameters but
+        // does not appear to honour them. The request below verifies serialization is accepted by
+        // the API even though the server-side filter is a no-op.
         var apiPagingRequest = new ApiPagingRequest
         {
             Sorting = new Dictionary<string, CollectionSortDirection>
             {
-                [PingenAttributesPropertyHelper<DeliveryProduct>.GetJsonPropertyName(product => product.PriceStartingFrom)] = CollectionSortDirection.DESC
+                [PingenAttributesPropertyHelper<DeliveryProduct>.GetJsonPropertyName(product => product.PriceStartingFrom)] =
+                    CollectionSortDirection.DESC
             },
-            Filtering = new(
+            Filtering = new KeyValuePair<string, object>(
                 CollectionFilterOperator.And,
                 new KeyValuePair<string, object>[]
                 {
-                    new(PingenAttributesPropertyHelper<DeliveryProduct>.GetJsonPropertyName(product => product.PriceCurrency), "CHF"),
-                    new(PingenAttributesPropertyHelper<DeliveryProduct>.GetJsonPropertyName(product => product.PriceStartingFrom), "<=1")
+                    new(
+                        PingenAttributesPropertyHelper<DeliveryProduct>.GetJsonPropertyName(product =>
+                            product.PriceCurrency), "CHF"),
+                    new(
+                        PingenAttributesPropertyHelper<DeliveryProduct>.GetJsonPropertyName(product =>
+                            product.PriceStartingFrom), "<=1")
                 })
         };
 
-        // Get page
         PingenApiClient.ShouldNotBeNull();
 
-        var res = await PingenApiClient!.Distributions.GetDeliveryProductsPage(apiPagingRequest);
-        res.ShouldNotBeNull();
-        res.ShouldSatisfyAllConditions(
-            () => res.IsSuccess.ShouldBeTrue(),
-            () => res.ApiError.ShouldBeNull(),
-            () => res.Data?.Data.ShouldNotBeNull()
-        );
+        ApiResult<CollectionResult<DeliveryProductData>> res =
+            await PingenApiClient!.Distributions.GetDeliveryProductsPage(apiPagingRequest);
+        AssertSuccess(res);
 
-        // Get all pages with filter
         var deliveryProducts = new List<DeliveryProductData>();
 
         ApiError? error = null;
         try
         {
-            await foreach (var page in PingenApiClient.Distributions.GetDeliveryProductsPageResultsAsync(apiPagingRequest))
-            {
+            await foreach (IEnumerable<DeliveryProductData> page in
+                           PingenApiClient.Distributions.GetDeliveryProductsPageResultsAsync(apiPagingRequest))
                 deliveryProducts.AddRange(page);
-            }
         }
         catch (PingenApiErrorException e)
         {

--- a/tests/PingenApiNet.Tests.E2E/Tests/FileUpload.cs
+++ b/tests/PingenApiNet.Tests.E2E/Tests/FileUpload.cs
@@ -23,9 +23,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using System.Net;
 using PingenApiNet.Abstractions.Enums.Api;
 using PingenApiNet.Abstractions.Enums.Letters;
 using PingenApiNet.Abstractions.Exceptions;
+using PingenApiNet.Abstractions.Models.Api;
+using PingenApiNet.Abstractions.Models.Api.Embedded;
+using PingenApiNet.Abstractions.Models.Api.Embedded.DataResults;
+using PingenApiNet.Abstractions.Models.Files;
+using PingenApiNet.Abstractions.Models.LetterEvents;
 using PingenApiNet.Abstractions.Models.Letters;
 using PingenApiNet.Abstractions.Models.Letters.Embedded;
 using PingenApiNet.Abstractions.Models.Letters.Views;
@@ -33,64 +39,65 @@ using PingenApiNet.Abstractions.Models.Letters.Views;
 namespace PingenApiNet.Tests.E2E.Tests;
 
 /// <summary>
-///
+///     End-to-end tests for the Pingen file-upload endpoint. Exercises the upload-URL handshake,
+///     the upload + create-letter combination, the letter events listing, and file download paths
+///     against the live staging API. Each letter created during the fixture is registered in the
+///     LIFO cleanup queue so it is cancelled or deleted at fixture teardown.
 /// </summary>
-public class TestGetFileUploadData : E2eTestBase
+[TestFixture]
+[Category("E2e")]
+public sealed class TestGetFileUploadData : E2eTestBase
 {
     /// <summary>
-    ///
+    ///     Verifies that the file-upload signed URL handshake returns a non-null payload.
     /// </summary>
     [Test]
     public async Task GetUploadData()
     {
         PingenApiClient.ShouldNotBeNull();
 
-        var res = await PingenApiClient!.Files.GetPath();
-        res.ShouldNotBeNull();
-        res.ShouldSatisfyAllConditions(
-            () => res.IsSuccess.ShouldBeTrue(),
-            () => res.ApiError.ShouldBeNull(),
-            () => res.Data?.Data.ShouldNotBeNull()
-        );
+        ApiResult<SingleResult<FileUploadData>> res = await PingenApiClient!.Files.GetPath();
+        AssertSuccess(res);
     }
 
+    /// <summary>
+    ///     Uploads the local sample PDF to the signed URL, creates a letter that references the
+    ///     upload, polls for the letter to reach <see cref="LetterStates.Valid" />, and submits it
+    ///     via the send endpoint. The created letter is registered in the LIFO cleanup queue and
+    ///     will be cancelled or deleted at fixture teardown.
+    /// </summary>
     [Test]
     public async Task GetUploadDataAndCreateLetter()
     {
         const string fileName = "sample.pdf";
         PingenApiClient.ShouldNotBeNull();
 
-        var res = await PingenApiClient!.Files.GetPath();
-        res.ShouldNotBeNull();
-        res.ShouldSatisfyAllConditions(
-            () => res.IsSuccess.ShouldBeTrue(),
-            () => res.ApiError.ShouldBeNull(),
-            () => res.Data?.Data.ShouldNotBeNull()
-        );
+        ApiResult<SingleResult<FileUploadData>> res = await PingenApiClient!.Files.GetPath();
+        AssertSuccess(res);
 
         MemoryStream stream = new();
         await File.OpenRead($"Assets/{fileName}").CopyToAsync(stream);
-        var uploadRes = await PingenApiClient.Files.UploadFile(res.Data!.Data, stream);
+        ExternalRequestResult uploadRes = await PingenApiClient.Files.UploadFile(res.Data!.Data, stream);
 
         uploadRes.ShouldSatisfyAllConditions(
             () => uploadRes.IsSuccess.ShouldBeTrue(),
-            () => uploadRes.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK)
+            () => uploadRes.StatusCode.ShouldBe(HttpStatusCode.OK)
         );
 
         var letterMetaData = new LetterMetaData
         {
-            Recipient = new()
+            Recipient = new LetterMetaDataContact
             {
-                Name = "manuel gysin",
+                Name = $"{TestPrefix}-recipient",
                 Street = "solecht",
                 Number = "42",
                 Zip = "3303",
                 City = "jegenstorf",
                 Country = "CH"
             },
-            Sender = new()
+            Sender = new LetterMetaDataContact
             {
-                Name = "Monika Muster",
+                Name = $"{TestPrefix}-sender",
                 Street = "Musterstrasse ",
                 Number = "12",
                 Zip = "1212",
@@ -99,49 +106,48 @@ public class TestGetFileUploadData : E2eTestBase
             }
         };
 
-        var resLetter = await PingenApiClient.Letters.Create(new()
-        {
-            Attributes = new()
+        ApiResult<SingleResult<LetterDataDetailed>> resLetter = await PingenApiClient.Letters.Create(
+            new DataPost<LetterCreate, LetterCreateRelationships>
             {
-                FileOriginalName = fileName,
-                FileUrl = res.Data.Data.Attributes.Url,
-                FileUrlSignature = res.Data.Data.Attributes.UrlSignature,
-                AddressPosition = LetterAddressPosition.left,
-                AutoSend = false,
-                DeliveryProduct = LetterCreateDeliveryProduct.Cheap,
-                PrintMode = LetterPrintMode.simplex,
-                PrintSpectrum = LetterPrintSpectrum.grayscale,
-                MetaData = letterMetaData
-            },
-            Type = PingenApiDataType.letters,
-            Relationships = LetterCreateRelationships.Create("1234567890")
-        });
+                Attributes = new LetterCreate
+                {
+                    FileOriginalName = $"{TestPrefix}-{fileName}",
+                    FileUrl = res.Data.Data.Attributes.Url,
+                    FileUrlSignature = res.Data.Data.Attributes.UrlSignature,
+                    AddressPosition = LetterAddressPosition.left,
+                    AutoSend = false,
+                    DeliveryProduct = LetterCreateDeliveryProduct.Cheap,
+                    PrintMode = LetterPrintMode.simplex,
+                    PrintSpectrum = LetterPrintSpectrum.grayscale,
+                    MetaData = letterMetaData
+                },
+                Type = PingenApiDataType.letters,
+                Relationships = LetterCreateRelationships.Create("1234567890")
+            });
 
-        resLetter.ShouldNotBeNull();
-        resLetter.ShouldSatisfyAllConditions(
-            () => resLetter.IsSuccess.ShouldBeTrue(),
-            () => resLetter.ApiError.ShouldBeNull(),
-            () => resLetter.Data?.Data.ShouldNotBeNull()
-        );
+        AssertSuccess(resLetter);
 
-        var letterId = resLetter.Data!.Data.Id;
+        string letterId = resLetter.Data!.Data.Id;
+        IPingenApiClient cleanupClient = PingenApiClient;
+        RegisterCleanup(async () => await TryCleanupLetter(cleanupClient, letterId));
 
-        var letterFromRemote = await PingenApiClient.Letters.Get(letterId);
+        ApiResult<SingleResult<LetterDataDetailed>> letterFromRemote = await PingenApiClient.Letters.Get(letterId);
         letterFromRemote.ShouldNotBeNull();
 
-        var letterEvents = await PingenApiClient.Letters.GetEventsPage(letterId, PingenApiLanguage.EnGB);
+        ApiResult<CollectionResult<LetterEventData>> letterEvents =
+            await PingenApiClient.Letters.GetEventsPage(letterId, PingenApiLanguage.EnGB);
         letterEvents.ShouldNotBeNull();
 
         const int attempts = 300;
         const int delaySeconds = 1;
         LetterDataDetailed? letter = null;
-        for (var attempt = 1; attempt <= attempts; attempt++)
+        for (int attempt = 1; attempt <= attempts; attempt++)
         {
-            var resultGetLetter = await PingenApiClient.Letters.Get(letterId);
+            ApiResult<SingleResult<LetterDataDetailed>> resultGetLetter = await PingenApiClient.Letters.Get(letterId);
             if (resultGetLetter.IsSuccess)
             {
-                var status = resultGetLetter.Data?.Data.Attributes.Status;
-                if (status == LetterStates.Valid)
+                string? status = resultGetLetter.Data?.Data.Attributes.Status;
+                if (status is LetterStates.Valid)
                 {
                     letter = resultGetLetter.Data!.Data;
                     break;
@@ -154,57 +160,62 @@ public class TestGetFileUploadData : E2eTestBase
         letter.ShouldNotBeNull();
         letter.Attributes.Status.ShouldBe(LetterStates.Valid);
 
-        var resSendLetter = await PingenApiClient.Letters.Send(new()
-        {
-            Type = PingenApiDataType.letters,
-            Attributes = new()
+        ApiResult<SingleResult<LetterDataDetailed>> resSendLetter = await PingenApiClient.Letters.Send(
+            new DataPatch<LetterSend>
             {
-                DeliveryProduct = LetterSendDeliveryProduct.PostAgA,
-                PrintMode = LetterPrintMode.simplex,
-                PrintSpectrum = LetterPrintSpectrum.color,
-                MetaData = letterMetaData
-            },
-            Id = letterId
-        });
+                Type = PingenApiDataType.letters,
+                Attributes = new LetterSend
+                {
+                    DeliveryProduct = LetterSendDeliveryProduct.PostAgA,
+                    PrintMode = LetterPrintMode.simplex,
+                    PrintSpectrum = LetterPrintSpectrum.color,
+                    MetaData = letterMetaData
+                },
+                Id = letterId
+            });
 
-        resSendLetter.ShouldNotBeNull();
-        resSendLetter.IsSuccess.ShouldBeTrue();
+        AssertSuccess(resSendLetter);
     }
 
+    /// <summary>
+    ///     Verifies that letter events can be retrieved in every supported language.
+    /// </summary>
     [Test]
     public async Task GetLetterEvents()
     {
         PingenApiClient.ShouldNotBeNull();
         const string letterId = "1540e30d-84cd-4425-bcc1-c3aff196d4da";
 
-        foreach (var language in new[]
+        foreach (string language in new[]
                  {
-                     PingenApiLanguage.EnGB,
-                     PingenApiLanguage.DeDE,
-                     PingenApiLanguage.DeCH,
-                     PingenApiLanguage.NlNL,
+                     PingenApiLanguage.EnGB, PingenApiLanguage.DeDE, PingenApiLanguage.DeCH, PingenApiLanguage.NlNL,
                      PingenApiLanguage.FrFR
                  })
         {
-            var res = await PingenApiClient!.Letters.GetEventsPage(letterId, language);
-            res.ShouldNotBeNull();
-            res.ShouldSatisfyAllConditions(
-                () => res.IsSuccess.ShouldBeTrue(),
-                () => res.ApiError.ShouldBeNull(),
-                () => res.Data?.Data.ShouldNotBeNull()
-            );
+            ApiResult<CollectionResult<LetterEventData>> res =
+                await PingenApiClient!.Letters.GetEventsPage(letterId, language);
+            AssertSuccess(res);
         }
     }
 
+    /// <summary>
+    ///     Verifies that an expired download URL produces a <see cref="PingenFileDownloadException" />.
+    /// </summary>
     [Test]
     public async Task GetFileDownloadError()
     {
         PingenApiClient.ShouldNotBeNull();
-        const string url = "https://pingen2-staging.objects.rma.cloudscale.ch/letters/20c1e673-03fe-4e19-ad45-9cdd85c5a940?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Z3YMWIXX6Y1G0KHUQDZ7%2F20221128%2Fregion1%2Fs3%2Faws4_request&X-Amz-Date=20221128T222323Z&X-Amz-SignedHeaders=host&X-Amz-Expires=86400&X-Amz-Signature=02705e5180cd082c5907d93e77fdb2d8c5a77938bc2e91a6e7c014ef953db9dd";
+        const string url =
+            "https://pingen2-staging.objects.rma.cloudscale.ch/letters/20c1e673-03fe-4e19-ad45-9cdd85c5a940?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Z3YMWIXX6Y1G0KHUQDZ7%2F20221128%2Fregion1%2Fs3%2Faws4_request&X-Amz-Date=20221128T222323Z&X-Amz-SignedHeaders=host&X-Amz-Expires=86400&X-Amz-Signature=02705e5180cd082c5907d93e77fdb2d8c5a77938bc2e91a6e7c014ef953db9dd";
 
-        await Should.ThrowAsync<PingenFileDownloadException>(async () => await PingenApiClient!.Letters.DownloadFileContent(new(url)));
+        await Should.ThrowAsync<PingenFileDownloadException>(async () =>
+            await PingenApiClient!.Letters.DownloadFileContent(new Uri(url)));
     }
 
+    /// <summary>
+    ///     Resolves the signed download URL for a known letter, downloads the resulting file content,
+    ///     and verifies the content can be persisted to disk.
+    /// </summary>
     [Test]
     public async Task GetFileDownload()
     {
@@ -212,7 +223,7 @@ public class TestGetFileUploadData : E2eTestBase
         const string letterId = "1540e30d-84cd-4425-bcc1-c3aff196d4da";
         const string filePath = "filepath.pdf";
 
-        var res = await PingenApiClient!.Letters.GetFileLocation(letterId);
+        ApiResult res = await PingenApiClient!.Letters.GetFileLocation(letterId);
         res.ShouldNotBeNull();
         res.ShouldSatisfyAllConditions(
             () => res.IsSuccess.ShouldBeTrue(),
@@ -220,11 +231,33 @@ public class TestGetFileUploadData : E2eTestBase
             () => res.Location.ShouldNotBeNull()
         );
 
-        var stream = await PingenApiClient.Letters.DownloadFileContent(res.Location!);
-        await using (var file = File.OpenWrite(filePath))
+        Stream stream = await PingenApiClient.Letters.DownloadFileContent(res.Location!);
+        await using (FileStream file = File.OpenWrite(filePath))
+        {
             await stream.CopyToAsync(file);
+        }
 
         File.Exists(filePath).ShouldBeTrue();
         File.Delete(filePath);
+    }
+
+    private static async Task TryCleanupLetter(IPingenApiClient client, string letterId)
+    {
+        try
+        {
+            ApiResult<SingleResult<LetterDataDetailed>> current = await client.Letters.Get(letterId);
+            if (!current.IsSuccess || current.Data?.Data is not { } detail)
+                return;
+
+            LetterAbilities abilities = detail.Meta.Abilities.Self;
+            if (abilities.Cancel is PingenApiAbility.ok)
+                await client.Letters.Cancel(letterId);
+            else if (abilities.Delete is PingenApiAbility.ok)
+                await client.Letters.Delete(letterId);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup: a single residual letter must not fail the fixture.
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #90

Part of the 100% test coverage roadmap (#82). Adds E2E test coverage for services group 2: Letter full workflow, Distribution, and Files.

### Changes

| File | Type | Description |
|------|------|-------------|
| `tests/PingenApiNet.Tests.E2E/Letters/LetterWorkflowE2eTests.cs` | New | Full live workflow: upload PDF → create letter → assert draft → send → optional cancel |
| `tests/PingenApiNet.Tests.E2E/Tests/DistributionGetDeliveryProducts.cs` | Updated | Inherit `E2eTestBase`, use `AssertSuccess()`, `[Category("E2e")]` tagging |
| `tests/PingenApiNet.Tests.E2E/Tests/FileUpload.cs` | Updated | Inherit `E2eTestBase`, register cleanup on created letters, `PG-E2E-{guid}` identifiers |

### Wave 7 Acceptance Criteria

- [x] `LetterWorkflowE2eTests` executes the full upload → create → send sequence (5 ordered test methods)
- [x] Letter state transitions verified at each step (`[Order(3)]` polls for `Valid`, `[Order(4)]` asserts post-send transition)
- [x] All created artefacts registered in LIFO cleanup queue (`TryCleanupLetter` with abilities check)
- [x] Orphan scavenging cleans leftover `"PG-E2E-"` letters from crashed prior runs (bootstrap client in `[OneTimeSetUp]`)
- [x] `DistributionGetDeliveryProducts` and `FileUpload` updated to inherit `E2eTestBase`
- [x] `dotnet test --filter Category=E2e --list-tests` discovers all expected E2E tests

### Verification

- Build: **PASS** — 0 errors, 0 new warnings
- Unit tests: **PASS** — 666 passed / 0 failed
- Integration tests: **PASS** — 150 passed / 0 failed
- E2E discovery: **PASS** — 5 new `LetterWorkflowE2eTests` methods + reclassified Distribution/File tests visible under `Category=E2e`
- Code review: **APPROVED** — no findings at confidence ≥ 75; single R# naming suggestion rejected (convention alignment)
- Live staging run requires `PingenApiNet__ClientId` / `PingenApiNet__ClientSecret` / `PingenApiNet__OrganisationId` in CI secrets

### Documentation

- `doc/analysis/2026-04-20-test-coverage-roadmap.md` — Wave 7 marked complete
- `CLAUDE.md` — E2E fixture list updated to include `LetterWorkflowE2eTests`