### PR TITLE
feat(http): optional caller-supplied default request headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ The API HTTP client has `AllowAutoRedirect = false` because the file-location en
 - **Connector service pattern**: Each Pingen resource area (letters, batches, webhooks, etc.) has a dedicated `IXxxService` interface and `XxxService : ConnectorService` implementation. `ConnectorService` provides `HandleResult` and `AutoPage` utilities.
 - **IPingenApiClient facade**: Consumer-facing entry point that aggregates all connector services as properties (`client.Letters.Create(...)`, `client.Files.UploadFile(...)`).
 - **Auto-pagination via IAsyncEnumerable**: Collection endpoints expose both `GetPage()` (single page, raw `ApiResult`) and `GetPageResultsAsync()` (`IAsyncEnumerable<IEnumerable<TData>>`). The `AutoPage` helper in `ConnectorService` loops until `Meta.CurrentPage >= Meta.LastPage`.
-- **Three HTTP clients**: `Pingen.Identity` (token endpoint), `Pingen.Api` (all resource API calls, no auto-redirect), `Pingen.Files` (external S3 URLs, anonymous).
+- **Three HTTP clients**: `Pingen.Identity` (token endpoint), `Pingen.Api` (all resource API calls, no auto-redirect), `Pingen.Files` (external S3 URLs, anonymous). Caller-supplied `IPingenConfiguration.DefaultRequestHeaders` are applied to identity + api only — `Pingen.Files` must stay free of pre-configured headers, an extra header risks a pre-signed URL signature rejection (ADR-004).
 - **JSON:API compliance**: All request/response shapes follow the JSON:API spec used by Pingen — `type`, `id`, `attributes`, `relationships`, `included`, `links`, `meta` fields.
 
 ## API Reference
@@ -165,9 +165,10 @@ Offline unit tests that require no API credentials or network access. Uses **NUn
 - `Webhooks` — offline deserialization of `Assets/webhook_sample.json`.
 - `Helpers/` — `PingenSerialisationHelper`, `PingenWebhookHelper`, `PingenAttributesPropertyHelper`, `PingenDateTimeConverter(Nullable)`, `PingenKeyValuePairStringObjectConverter` (comprehensive coverage for edge cases, nullability, missing properties, invalid formats, and nested collections).
 - `Models/` — `ApiResult`, `DataPost`/`DataPatch`, `ExternalRequestResult`, `IncludedCollection`, `PingenConfiguration`.
-- `Services/` — `PingenApiClient` facade + `PingenConnectionHandler` (OAuth token lifecycle, re-auth, rate-limit header parsing, multi-tenant token isolation regression test for #22, concurrent-login double-check regression for #27).
+- `Services/` — `PingenApiClient` facade + `PingenConnectionHandler` (OAuth token lifecycle, re-auth, rate-limit header parsing, multi-tenant token isolation regression test for #22, concurrent-login double-check regression for #27) + `PingenHttpClients.Create` (default request headers on identity/api, never on the external files client).
+- `Configuration/` — `HttpClientExtension.ApplyDefaultRequestHeaders` contract (reserved names skipped, invalid name/value skipped, re-apply replaces instead of appends, never throws).
 - `Services/Connectors/` — per-connector unit tests using NSubstitute-mocked `IPingenConnectionHandler` (verifies endpoint path construction and error/edge-case handling for Batches, Distribution, Files, Letters, Organisations, Users, Webhooks, and the shared `ConnectorService`).
-- `AspNetCore/` — `PingenServiceCollection.AddPingenServices()` DI registration.
+- `AspNetCore/` — `PingenServiceCollection.AddPingenServices()` DI registration, incl. the `IPingenConfiguration.DefaultRequestHeaders` contract and the deliberate `Pingen.Files` exclusion (ADR-004).
 - `Enums/` — `BatchIconSerializationTests`, `LetterEnumSerializationTests`, `AllEnumsSerializationTests` (enum and string-constant serialization round-trips for every value).
 - `Exceptions/` — the three Pingen exception types.
 
@@ -177,7 +178,7 @@ Offline unit tests that require no API credentials or network access. Uses **NUn
 Offline in-process integration tests using **NUnit 4 + Shouldly + WireMock.Net + Bogus**. Spins up a local WireMock HTTP server per test fixture, stubs both the Pingen API and the OAuth token endpoint, and exercises a real `PingenApiClient` wired to that server. Covers request/response round-trips, JSON:API envelope shaping, auto-pagination (`InScenario` state machines), and the three-HTTP-client routing (identity / api / external-files):
 
 - `BatchServiceTests`, `DistributionServiceTests`, `FilesServiceTests`, `LetterServiceTests`, `OrganisationServiceTests`, `PingenApiClientTests`, `UserServiceTests`, `WebhookServiceTests`.
-- `CrossCutting/` — `CancellationTokenTests`, `ConcurrencyTests`, `EdgeCaseTests`, `ErrorHandlingTests`, `PaginationTests`.
+- `CrossCutting/` — `CancellationTokenTests`, `ConcurrencyTests`, `DefaultRequestHeadersTests`, `EdgeCaseTests`, `ErrorHandlingTests`, `IdempotencyTests`, `PaginationTests`, `QueryStringSerializationTests`.
 - `IntegrationTestBase.cs` — handles `[OneTimeSetUp]` WireMock startup, per-test reset, token-endpoint stub, client construction, and disposal.
 - `Helpers/JsonApiStubHelper.cs` — low-level JSON:API envelope builder.
 - `Helpers/PingenResponseFactory.cs` — centralised WireMock JSON:API response builder using Bogus for realistic test data generation.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ services.AddPingenServices(new PingenConfiguration
 });
 ```
 
+Optionally, set `DefaultRequestHeaders` to add static headers to every request, e.g. to identify the calling application.
+```c#
+services.AddPingenServices(new PingenConfiguration
+{
+    /****/
+    DefaultRequestHeaders = new Dictionary<string, string>
+    {
+        ["X-Your-Client"] = "your-app/1.0.0 (prd)"
+    }
+});
+```
+
+Those headers are applied to the identity and the API HTTP client only, and deliberately **not** to the files HTTP client, which uploads to and downloads from pre-signed third party storage URLs that must not receive any pre-configured header (see [ADR-004](doc/architecture/decisions/004-three-http-clients.md)). Static values only, per request values belong on the `HttpRequestMessage`. The reserved names `Authorization`, `Accept`, `Host` and `Idempotency-Key` are silently skipped, as are invalid entries (blank name or value, invalid header name characters, control characters such as CR/LF in the value) — a configured header can never make a request fail. The same is available for the standalone path via `PingenHttpClients.Create(configuration)`, and as the public `HttpClient.ApplyDefaultRequestHeaders(headers)` extension for callers that construct the `HttpClient` instances themselves.
+
 #### 6. Receive Webhooks
 
 Validate webhook and extract data.

--- a/doc/architecture/decisions/004-three-http-clients.md
+++ b/doc/architecture/decisions/004-three-http-clients.md
@@ -25,6 +25,14 @@ Three named `HttpClient` instances are defined in `PingenHttpClients.Names`:
 
 In the ASP.NET Core path (`PingenServiceCollection.AddPingenServices`), these are registered via `services.AddHttpClient(name, configure)` and resolved via `IHttpClientFactory`. In the standalone path (used by tests), `PingenHttpClients.Create(configuration)` constructs `HttpClient` instances directly.
 
+### Caller-supplied default request headers (added in 1.4.0)
+
+`IPingenConfiguration.DefaultRequestHeaders` lets a consumer add static headers (e.g. a caller-identification header such as `X-Amanda-Client`) to the clients this library configures. It is applied through `HttpClientExtension.ApplyDefaultRequestHeaders` at both construction sites (`PingenServiceCollection.AddPingenServices` and `PingenHttpClients.Create`) to **`Pingen.Identity` and `Pingen.Api` only**.
+
+**`Pingen.Files` is deliberately excluded.** That client talks to pre-signed third-party storage URLs, not to Pingen — this ADR requires it to carry no pre-configured headers, and an additional header risks a signature rejection by the storage provider. The exclusion is pinned by `AddPingenServices_WithDefaultRequestHeaders_DoesNotApplyToFilesClient`, `Create_WithDefaultRequestHeaders_DoesNotApplyToExternalClient` and the wire-level `ExternalFileUpload_ShouldNotSendConfiguredDefaultRequestHeader`. Do not "fix" the apparent inconsistency by applying the headers there too.
+
+The reserved header names `Authorization`, `Accept`, `Host` and `Idempotency-Key` are silently skipped, because the header collections append on a duplicate name instead of throwing — an unguarded caller entry would transmit two values and break authentication, content negotiation or idempotency. Invalid entries (blank name or value, invalid header-name token characters, control characters such as CR/LF in the value) are skipped as well, so a configured header can never turn into a failed request.
+
 ## Consequences
 
 **Good:**

--- a/src/PingenApiNet.AspNetCore/PingenServiceCollection.cs
+++ b/src/PingenApiNet.AspNetCore/PingenServiceCollection.cs
@@ -24,6 +24,7 @@ SOFTWARE.
 */
 
 using Microsoft.Extensions.DependencyInjection;
+using PingenApiNet.Configuration;
 using PingenApiNet.Interfaces;
 using PingenApiNet.Interfaces.Connectors;
 using PingenApiNet.Services;
@@ -73,11 +74,16 @@ public static class PingenServiceCollection
             identityClient.BaseAddress = new(pingenConfiguration.IdentityUri);
             identityClient.DefaultRequestHeaders.Accept.Clear();
             identityClient.DefaultRequestHeaders.Accept.Add(new("application/x-www-form-urlencoded"));
+            identityClient.ApplyDefaultRequestHeaders(pingenConfiguration.DefaultRequestHeaders);
         });
         services.AddHttpClient(PingenHttpClients.Names.Api, apiClient =>
         {
             apiClient.BaseAddress = new(pingenConfiguration.BaseUri);
+            apiClient.ApplyDefaultRequestHeaders(pingenConfiguration.DefaultRequestHeaders);
         }).ConfigurePrimaryHttpMessageHandler(p => new HttpClientHandler { AllowAutoRedirect = false });
+        // DELIBERATE: the files client targets pre signed THIRD PARTY storage URLs, not the Pingen API. ADR-004
+        // requires it to carry no pre-configured headers, an additional header risks a signature rejection.
+        // Therefore IPingenConfiguration.DefaultRequestHeaders is NOT applied here, do not "fix" this inconsistency.
         services.AddHttpClient(PingenHttpClients.Names.Files);
         services.AddScoped<PingenHttpClients>(sp => new(sp.GetRequiredService<IHttpClientFactory>()));
         services.AddScoped<IPingenConnectionHandler, PingenConnectionHandler>();

--- a/src/PingenApiNet/Configuration/HttpClientExtension.cs
+++ b/src/PingenApiNet/Configuration/HttpClientExtension.cs
@@ -1,0 +1,114 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace PingenApiNet.Configuration;
+
+/// <summary>
+/// Extensions to configure the <see cref="HttpClient"/> instances used by this library.
+/// </summary>
+public static class HttpClientExtension
+{
+    /// <summary>
+    /// Header names owned by this library, which are therefore never taken from the caller supplied headers.
+    /// The header collections append on a duplicate name instead of throwing, so an unguarded caller entry
+    /// would transmit two values and break authentication, content negotiation or idempotency.
+    /// </summary>
+    private static readonly HashSet<string> ReservedHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Accept",
+        "Host",
+        "Idempotency-Key"
+    };
+
+    /// <summary>
+    /// Valid header name token characters in addition to ALPHA and DIGIT, as defined by RFC 9110.
+    /// </summary>
+    private const string AdditionalHeaderNameTokenCharacters = "!#$%&'*+-.^_`|~";
+
+    /// <summary>
+    /// Applies additional static default request headers to the given client, e.g. to identify the calling
+    /// application at the Pingen API. Intended to be applied once per <see cref="HttpClient"/>, on
+    /// <see cref="HttpClient.DefaultRequestHeaders"/>, with static values only. Per request values must be
+    /// set on the <see cref="HttpRequestMessage"/> instead.
+    /// <br/><br/>
+    /// Semantics:
+    /// <list type="bullet">
+    /// <item>Applied after the headers this library configures itself. Each header is removed before it is
+    /// added, so applying the same headers twice replaces instead of appends.</item>
+    /// <item>The reserved header names <c>Authorization</c>, <c>Accept</c>, <c>Host</c> and
+    /// <c>Idempotency-Key</c> are silently skipped, case insensitive. The header collections append on a
+    /// duplicate name instead of throwing, so an unguarded caller entry would transmit two values and break
+    /// authentication or idempotency.</item>
+    /// <item>Never throws. A <c>null</c> or empty dictionary is a no-op. A blank name or value, a name
+    /// containing an invalid header name token character, or a value containing a control character
+    /// (below 0x20 or 0x7F, notably CR/LF) is skipped. This is not cosmetic:
+    /// <c>TryAddWithoutValidation</c> accepts a value containing CR/LF and the underlying handler then
+    /// throws when the request is sent.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="client">The client to apply the headers to.</param>
+    /// <param name="headers">Optional, additional static default request headers to apply.</param>
+    /// <returns>The same <paramref name="client"/>, to allow chaining.</returns>
+    public static HttpClient ApplyDefaultRequestHeaders(this HttpClient client, IReadOnlyDictionary<string, string>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+            return client;
+
+        foreach (var (name, value) in headers)
+        {
+            if (!IsApplicableHeaderName(name) || !IsApplicableHeaderValue(value))
+                continue;
+
+            client.DefaultRequestHeaders.Remove(name);
+            client.DefaultRequestHeaders.TryAddWithoutValidation(name, value);
+        }
+
+        return client;
+    }
+
+    /// <summary>
+    /// Checks whether the given header name is neither blank nor reserved and consists of valid token characters only.
+    /// </summary>
+    /// <param name="name">The header name to check.</param>
+    /// <returns>True if the header name may be applied.</returns>
+    private static bool IsApplicableHeaderName(string? name)
+    {
+        return !string.IsNullOrWhiteSpace(name)
+               && !ReservedHeaderNames.Contains(name)
+               && name.All(character => char.IsAsciiLetterOrDigit(character) || AdditionalHeaderNameTokenCharacters.Contains(character));
+    }
+
+    /// <summary>
+    /// Checks whether the given header value is neither blank nor contains a control character.
+    /// </summary>
+    /// <param name="value">The header value to check.</param>
+    /// <returns>True if the header value may be applied.</returns>
+    private static bool IsApplicableHeaderValue(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value)
+               && !value.Any(character => character < ' ' || character == (char)0x7F);
+    }
+}

--- a/src/PingenApiNet/Interfaces/IPingenConfiguration.cs
+++ b/src/PingenApiNet/Interfaces/IPingenConfiguration.cs
@@ -60,6 +60,16 @@ public interface IPingenConfiguration
     /// The signing key is also stated as secret sometimes in the pingen documentation.
     /// </summary>
     public Dictionary<string, string>? WebhookSigningKeys { get; set; }
+
+    /// <summary>
+    /// Optional, additional static default request headers, e.g. to identify the calling application at the Pingen API.
+    /// Applied to the identity and the API HTTP client only, and deliberately NOT to the files HTTP client, which
+    /// targets pre signed third party storage URLs that must not receive any pre-configured header (see ADR-004).
+    /// See <see cref="PingenApiNet.Configuration.HttpClientExtension.ApplyDefaultRequestHeaders"/> for the exact
+    /// semantics: static values only, reserved header names are silently skipped, invalid entries are skipped and
+    /// nothing ever throws.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? DefaultRequestHeaders => null;
 }
 
 /// <summary>

--- a/src/PingenApiNet/Services/PingenConfiguration.cs
+++ b/src/PingenApiNet/Services/PingenConfiguration.cs
@@ -47,4 +47,7 @@ public sealed record PingenConfiguration : IPingenConfiguration
 
     /// <inheritdoc />
     public Dictionary<string, string>? WebhookSigningKeys { get; set; }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string>? DefaultRequestHeaders { get; set; }
 }

--- a/src/PingenApiNet/Services/PingenHttpClients.cs
+++ b/src/PingenApiNet/Services/PingenHttpClients.cs
@@ -1,3 +1,4 @@
+using PingenApiNet.Configuration;
 using PingenApiNet.Interfaces;
 
 namespace PingenApiNet.Services;
@@ -71,12 +72,17 @@ public class PingenHttpClients(HttpClient identityClient, HttpClient apiClient, 
         };
         identityClient.DefaultRequestHeaders.Accept.Clear();
         identityClient.DefaultRequestHeaders.Accept.Add(new("application/x-www-form-urlencoded"));
+        identityClient.ApplyDefaultRequestHeaders(configuration.DefaultRequestHeaders);
 
         var apiClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
         {
             BaseAddress = new(configuration.BaseUri)
         };
+        apiClient.ApplyDefaultRequestHeaders(configuration.DefaultRequestHeaders);
 
+        // DELIBERATE: the external client targets pre signed THIRD PARTY storage URLs, not the Pingen API. ADR-004
+        // requires it to carry no pre-configured headers, an additional header risks a signature rejection.
+        // Therefore IPingenConfiguration.DefaultRequestHeaders is NOT applied here, do not "fix" this inconsistency.
         var externalClient = new HttpClient();
 
         return new(identityClient, apiClient, externalClient);

--- a/tests/PingenApiNet.Tests.Integration/IntegrationTestBase.cs
+++ b/tests/PingenApiNet.Tests.Integration/IntegrationTestBase.cs
@@ -1,3 +1,4 @@
+using PingenApiNet.Configuration;
 using PingenApiNet.Services.Connectors;
 using PingenApiNet.Tests.Integration.Helpers;
 using WireMock.RequestBuilders;
@@ -30,6 +31,12 @@ public abstract class IntegrationTestBase
     private HttpClient _identityClient = null!;
     private HttpClient _apiClient = null!;
     private HttpClient _externalClient = null!;
+
+    /// <summary>
+    /// Optional, additional static default request headers to configure. Override in a fixture to exercise
+    /// <see cref="IPingenConfiguration.DefaultRequestHeaders"/>.
+    /// </summary>
+    protected virtual IReadOnlyDictionary<string, string>? DefaultRequestHeaders => null;
 
     /// <summary>
     /// Start WireMock server once per test fixture.
@@ -68,8 +75,14 @@ public abstract class IntegrationTestBase
             IdentityUri = "https://identity.test.pingen.com/",
             ClientId = "test-client-id",
             ClientSecret = "test-client-secret",
-            DefaultOrganisationId = TestOrganisationId
+            DefaultOrganisationId = TestOrganisationId,
+            DefaultRequestHeaders = DefaultRequestHeaders
         };
+
+        // Mirror the library construction sites: the identity and API clients receive the configured default request
+        // headers, the external client deliberately does not, it targets pre signed third party URLs (see ADR-004).
+        _identityClient.ApplyDefaultRequestHeaders(configuration.DefaultRequestHeaders);
+        _apiClient.ApplyDefaultRequestHeaders(configuration.DefaultRequestHeaders);
 
         var httpClients = new PingenHttpClients(_identityClient, _apiClient, _externalClient);
         var connectionHandler = new PingenConnectionHandler(configuration, httpClients);

--- a/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/DefaultRequestHeadersTests.cs
+++ b/tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/DefaultRequestHeadersTests.cs
@@ -1,0 +1,162 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using Bogus;
+using PingenApiNet.Abstractions.Enums.Api;
+using PingenApiNet.Abstractions.Models.Files;
+using PingenApiNet.Tests.Integration.Helpers;
+using WireMock.Logging;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Types;
+
+namespace PingenApiNet.Tests.Integration.Tests.CrossCutting;
+
+/// <summary>
+///     Cross-cutting integration tests verifying that <see cref="IPingenConfiguration.DefaultRequestHeaders" />
+///     reaches the wire on the identity and API HTTP clients, and never on the external files client, which
+///     targets pre signed third party storage URLs (see ADR-004).
+/// </summary>
+[TestFixture]
+public sealed class DefaultRequestHeadersTests : IntegrationTestBase
+{
+    private const string HeaderName = "X-Amanda-Client";
+
+    private const string HeaderValue = "AMANDA.discountfit/2f3a9c1 (Backend; env=int)";
+
+    private const string IdempotencyKeyHeader = "Idempotency-Key";
+
+    private static readonly Faker _faker = new();
+
+    /// <inheritdoc />
+    protected override IReadOnlyDictionary<string, string>? DefaultRequestHeaders => new Dictionary<string, string>
+    {
+        [HeaderName] = HeaderValue,
+        // Reserved, must never reach the wire from here
+        [IdempotencyKeyHeader] = "caller-supplied-idempotency-key"
+    };
+
+    /// <summary>
+    ///     Verifies that the configured default request headers are sent to the Pingen API.
+    /// </summary>
+    [Test]
+    public async Task ApiRequest_ShouldSendConfiguredDefaultRequestHeader()
+    {
+        Server.StubJsonGet(OrgPath("deliveries/letters"), PingenResponseFactory.LetterCollection());
+
+        await Client.Letters.GetPage();
+
+        GetRequestHeaderValues(OrgPath("deliveries/letters"), "GET", HeaderName).ShouldBe([HeaderValue]);
+    }
+
+    /// <summary>
+    ///     Verifies that the configured default request headers are sent to the Pingen identity service.
+    /// </summary>
+    [Test]
+    public async Task IdentityRequest_ShouldSendConfiguredDefaultRequestHeader()
+    {
+        Server.StubJsonGet(OrgPath("deliveries/letters"), PingenResponseFactory.LetterCollection());
+
+        await Client.Letters.GetPage();
+
+        GetRequestHeaderValues("/auth/access-tokens", "POST", HeaderName).ShouldBe([HeaderValue]);
+    }
+
+    /// <summary>
+    ///     Verifies that the configured default request headers are NOT sent to the external file storage. That
+    ///     request targets a pre signed third party URL, an additional header risks a signature rejection.
+    /// </summary>
+    [Test]
+    public async Task ExternalFileUpload_ShouldNotSendConfiguredDefaultRequestHeader()
+    {
+        string uploadPath = $"/upload/{Guid.NewGuid()}";
+
+        Server
+            .Given(Request.Create()
+                .WithPath(uploadPath)
+                .UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var fileUploadData = new FileUploadData
+        {
+            Id = Guid.NewGuid().ToString(),
+            Type = PingenApiDataType.file_uploads,
+            Attributes = new FileUpload(
+                $"{Server.Url}{uploadPath}",
+                _faker.Random.AlphaNumeric(32),
+                DateTime.UtcNow.AddHours(1))
+        };
+
+        using var stream = new MemoryStream(_faker.Random.Bytes(128));
+
+        await Client.Files.UploadFile(fileUploadData, stream);
+
+        GetRequestHeaderValues(uploadPath, "PUT", HeaderName).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     Verifies that a reserved header name configured as a default request header never reaches the wire, so it
+    ///     can neither duplicate nor overwrite the idempotency key this library sends itself.
+    /// </summary>
+    [Test]
+    public async Task ApiRequest_WithIdempotencyKey_ShouldSendOnlyTheIdempotencyKeyOfThisLibrary()
+    {
+        string idempotencyKey = Guid.NewGuid().ToString();
+        string letterId = Guid.NewGuid().ToString();
+
+        Server
+            .Given(Request.Create()
+                .WithPath(OrgPath($"deliveries/letters/{letterId}/cancel"))
+                .UsingPatch())
+            .RespondWith(Response.Create()
+                .WithStatusCode(204)
+                .WithHeader("X-Request-ID", Guid.NewGuid().ToString()));
+
+        await Client.Letters.Cancel(letterId, idempotencyKey);
+
+        GetRequestHeaderValues(OrgPath($"deliveries/letters/{letterId}/cancel"), "PATCH", IdempotencyKeyHeader)
+            .ShouldBe([idempotencyKey]);
+    }
+
+    /// <summary>
+    ///     Get all values of the given header on the recorded request, or an empty array if the header is not set.
+    /// </summary>
+    /// <param name="path">URL path of the recorded request.</param>
+    /// <param name="method">HTTP method of the recorded request.</param>
+    /// <param name="name">The header name to read.</param>
+    /// <returns>All values of the given header.</returns>
+    private string[] GetRequestHeaderValues(string path, string method, string name)
+    {
+        ILogEntry entry = Server.LogEntries.Single(e =>
+            e.RequestMessage?.Path == path &&
+            string.Equals(e.RequestMessage?.Method, method, StringComparison.OrdinalIgnoreCase));
+
+        IDictionary<string, WireMockList<string>>? headers = entry.RequestMessage!.Headers;
+
+        return headers is not null && headers.TryGetValue(name, out WireMockList<string>? values)
+            ? [.. values]
+            : [];
+    }
+}

--- a/tests/PingenApiNet.UnitTests/Tests/AspNetCore/PingenServiceCollectionTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/AspNetCore/PingenServiceCollectionTests.cs
@@ -9,6 +9,10 @@ namespace PingenApiNet.UnitTests.Tests.AspNetCore;
 /// </summary>
 public class PingenServiceCollectionTests
 {
+    private const string HeaderName = "X-Amanda-Client";
+
+    private const string HeaderValue = "AMANDA.discountfit/2f3a9c1 (Backend; env=int)";
+
     /// <summary>
     /// Verifies that AddPingenServices registers all expected services
     /// </summary>
@@ -110,5 +114,183 @@ public class PingenServiceCollectionTests
         var client = scope.ServiceProvider.GetService<IPingenApiClient>();
 
         client.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Verifies that the configured default request headers are applied to the identity and the API http client
+    /// </summary>
+    [Test]
+    public void AddPingenServices_WithDefaultRequestHeaders_AppliesThemToIdentityAndApiClients()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPingenServices(BuildConfiguration(new Dictionary<string, string> { [HeaderName] = HeaderValue }));
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        using var identityClient = factory.CreateClient(PingenHttpClients.Names.Identity);
+        using var apiClient = factory.CreateClient(PingenHttpClients.Names.Api);
+
+        services.ShouldSatisfyAllConditions(
+            () => GetHeaderValues(identityClient, HeaderName).ShouldBe([HeaderValue]),
+            () => GetHeaderValues(apiClient, HeaderName).ShouldBe([HeaderValue]));
+    }
+
+    /// <summary>
+    /// Verifies that the configured default request headers are NOT applied to the files http client. That client
+    /// targets pre signed third party storage URLs, which must not receive any pre-configured header (see ADR-004).
+    /// </summary>
+    [Test]
+    public void AddPingenServices_WithDefaultRequestHeaders_DoesNotApplyToFilesClient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPingenServices(BuildConfiguration(new Dictionary<string, string> { [HeaderName] = HeaderValue }));
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        using var filesClient = factory.CreateClient(PingenHttpClients.Names.Files);
+
+        filesClient.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that the default request headers are applied after the headers configured by this library,
+    /// without dropping them
+    /// </summary>
+    [Test]
+    public void AddPingenServices_WithDefaultRequestHeaders_KeepsAcceptHeaderOnIdentityClient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPingenServices(BuildConfiguration(new Dictionary<string, string> { [HeaderName] = HeaderValue }));
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        using var identityClient = factory.CreateClient(PingenHttpClients.Names.Identity);
+
+        identityClient.DefaultRequestHeaders.Accept.ShouldHaveSingleItem()
+            .MediaType.ShouldBe("application/x-www-form-urlencoded");
+    }
+
+    /// <summary>
+    /// Verifies that reserved header names are silently skipped, so they can never duplicate or overwrite a header
+    /// owned by this library
+    /// </summary>
+    [TestCase("Authorization")]
+    [TestCase("Accept")]
+    [TestCase("Host")]
+    [TestCase("Idempotency-Key")]
+    public void AddPingenServices_WithReservedDefaultRequestHeader_SkipsIt(string name)
+    {
+        var services = new ServiceCollection();
+
+        services.AddPingenServices(BuildConfiguration(new Dictionary<string, string> { [name] = "caller-value" }));
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        using var apiClient = factory.CreateClient(PingenHttpClients.Names.Api);
+
+        GetHeaderValues(apiClient, name).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that invalid default request headers are skipped instead of failing the client configuration
+    /// </summary>
+    [Test]
+    public void AddPingenServices_WithInvalidDefaultRequestHeaders_SkipsThemWithoutThrowing()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPingenServices(BuildConfiguration(new Dictionary<string, string>
+        {
+            ["X Invalid Name"] = "value",
+            ["X-Invalid-Value"] = "value\r\nX-Injected: evil",
+            ["X-Blank-Value"] = " ",
+            [HeaderName] = HeaderValue
+        }));
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        HttpClient apiClient = null!;
+
+        Should.NotThrow(() => apiClient = factory.CreateClient(PingenHttpClients.Names.Api));
+
+        using (apiClient)
+        {
+            apiClient.ShouldSatisfyAllConditions(
+                () => GetHeaderValues(apiClient, HeaderName).ShouldBe([HeaderValue]),
+                () => apiClient.DefaultRequestHeaders.Count().ShouldBe(1));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that every client created from the factory carries the header exactly once
+    /// </summary>
+    [Test]
+    public void AddPingenServices_WithDefaultRequestHeaders_AppliesThemOncePerCreatedClient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPingenServices(BuildConfiguration(new Dictionary<string, string> { [HeaderName] = HeaderValue }));
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        using var firstApiClient = factory.CreateClient(PingenHttpClients.Names.Api);
+        using var secondApiClient = factory.CreateClient(PingenHttpClients.Names.Api);
+
+        services.ShouldSatisfyAllConditions(
+            () => GetHeaderValues(firstApiClient, HeaderName).ShouldBe([HeaderValue]),
+            () => GetHeaderValues(secondApiClient, HeaderName).ShouldBe([HeaderValue]));
+    }
+
+    /// <summary>
+    /// Verifies that the http clients carry no additional headers when none are configured, e.g. when registered
+    /// through the overload taking the single configuration values
+    /// </summary>
+    [Test]
+    public void AddPingenServices_WithoutDefaultRequestHeaders_AppliesNoAdditionalHeaders()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPingenServices(
+            "https://api.example.com/",
+            "https://identity.example.com/",
+            "test-client-id",
+            "test-client-secret",
+            "test-org-id");
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        using var identityClient = factory.CreateClient(PingenHttpClients.Names.Identity);
+        using var apiClient = factory.CreateClient(PingenHttpClients.Names.Api);
+        using var filesClient = factory.CreateClient(PingenHttpClients.Names.Files);
+
+        services.ShouldSatisfyAllConditions(
+            () => identityClient.DefaultRequestHeaders.ShouldHaveSingleItem().Key.ShouldBe("Accept"),
+            () => apiClient.DefaultRequestHeaders.ShouldBeEmpty(),
+            () => filesClient.DefaultRequestHeaders.ShouldBeEmpty());
+    }
+
+    /// <summary>
+    /// Build a configuration for the tests, optionally with additional default request headers.
+    /// </summary>
+    /// <param name="defaultRequestHeaders">Optional, additional static default request headers.</param>
+    /// <returns>The configuration to register.</returns>
+    private static PingenConfiguration BuildConfiguration(IReadOnlyDictionary<string, string>? defaultRequestHeaders = null)
+    {
+        return new PingenConfiguration
+        {
+            BaseUri = "https://api.example.com/",
+            IdentityUri = "https://identity.example.com/",
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            DefaultOrganisationId = "test-org-id",
+            DefaultRequestHeaders = defaultRequestHeaders
+        };
+    }
+
+    /// <summary>
+    /// Get all values of the given header, or an empty array if the header is not set.
+    /// </summary>
+    /// <param name="client">The client to read the header from.</param>
+    /// <param name="name">The header name to read.</param>
+    /// <returns>All values of the given header.</returns>
+    private static string[] GetHeaderValues(HttpClient client, string name)
+    {
+        return client.DefaultRequestHeaders.TryGetValues(name, out var values) ? values.ToArray() : [];
     }
 }

--- a/tests/PingenApiNet.UnitTests/Tests/Configuration/HttpClientExtensionTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Configuration/HttpClientExtensionTests.cs
@@ -1,0 +1,242 @@
+using System.Net.Http.Headers;
+using PingenApiNet.Configuration;
+
+namespace PingenApiNet.UnitTests.Tests.Configuration;
+
+/// <summary>
+/// Unit tests for <see cref="HttpClientExtension.ApplyDefaultRequestHeaders"/>
+/// </summary>
+public class HttpClientExtensionTests
+{
+    private const string HeaderName = "X-Amanda-Client";
+
+    private const string HeaderValue = "AMANDA.discountfit/2f3a9c1 (Backend; env=int)";
+
+    /// <summary>
+    /// Verifies that valid headers are applied to the default request headers
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_WithValidHeaders_AppliesThem()
+    {
+        using var client = new HttpClient();
+
+        client.ApplyDefaultRequestHeaders(new Dictionary<string, string>
+        {
+            [HeaderName] = HeaderValue,
+            ["X-Correlation-Source"] = "unit-test"
+        });
+
+        client.ShouldSatisfyAllConditions(
+            () => GetHeaderValues(client, HeaderName).ShouldBe([HeaderValue]),
+            () => GetHeaderValues(client, "X-Correlation-Source").ShouldBe(["unit-test"]));
+    }
+
+    /// <summary>
+    /// Verifies that the client itself is returned to allow chaining
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_ReturnsSameClientForChaining()
+    {
+        using var client = new HttpClient();
+
+        var returned = client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [HeaderName] = HeaderValue });
+
+        returned.ShouldBeSameAs(client);
+    }
+
+    /// <summary>
+    /// Verifies that null headers are a no-op
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_WithNullHeaders_IsNoOp()
+    {
+        using var client = new HttpClient();
+
+        Should.NotThrow(() => client.ApplyDefaultRequestHeaders(null));
+
+        client.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that empty headers are a no-op
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_WithEmptyHeaders_IsNoOp()
+    {
+        using var client = new HttpClient();
+
+        Should.NotThrow(() => client.ApplyDefaultRequestHeaders(new Dictionary<string, string>()));
+
+        client.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that a blank header name is skipped without throwing
+    /// </summary>
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase("\t")]
+    public void ApplyDefaultRequestHeaders_WithBlankName_SkipsHeader(string name)
+    {
+        using var client = new HttpClient();
+
+        Should.NotThrow(() => client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [name] = HeaderValue }));
+
+        client.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that a blank header value is skipped without throwing
+    /// </summary>
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase("\t")]
+    public void ApplyDefaultRequestHeaders_WithBlankValue_SkipsHeader(string value)
+    {
+        using var client = new HttpClient();
+
+        Should.NotThrow(() => client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [HeaderName] = value }));
+
+        client.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that a value containing a control character is skipped. TryAddWithoutValidation would accept it,
+    /// and the request would then fail when it is sent.
+    /// </summary>
+    [TestCase("value\r\nX-Injected: evil")]
+    [TestCase("value\rmore")]
+    [TestCase("value\nmore")]
+    [TestCase("value\u007Fmore")]
+    [TestCase("value\u0000more")]
+    public void ApplyDefaultRequestHeaders_WithControlCharacterInValue_SkipsHeader(string value)
+    {
+        using var client = new HttpClient();
+
+        Should.NotThrow(() => client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [HeaderName] = value }));
+
+        client.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that a name containing an invalid header name token character is skipped
+    /// </summary>
+    [TestCase("X Amanda Client")]
+    [TestCase("X-Amanda:Client")]
+    [TestCase("X-Amanda\r\nClient")]
+    [TestCase("X-Amanda/Client")]
+    [TestCase("X-Amändä-Client")]
+    public void ApplyDefaultRequestHeaders_WithInvalidNameToken_SkipsHeader(string name)
+    {
+        using var client = new HttpClient();
+
+        Should.NotThrow(() => client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [name] = HeaderValue }));
+
+        client.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that reserved header names are silently skipped, case insensitive. The header collections append on a
+    /// duplicate name instead of throwing, so an unguarded entry would transmit two values.
+    /// </summary>
+    [TestCase("Authorization")]
+    [TestCase("authorization")]
+    [TestCase("Accept")]
+    [TestCase("ACCEPT")]
+    [TestCase("Host")]
+    [TestCase("host")]
+    [TestCase("Idempotency-Key")]
+    [TestCase("idempotency-key")]
+    public void ApplyDefaultRequestHeaders_WithReservedName_SkipsHeader(string name)
+    {
+        using var client = new HttpClient();
+
+        client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [name] = HeaderValue });
+
+        client.DefaultRequestHeaders.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that a reserved header name neither replaces nor duplicates the value this library set itself
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_WithReservedName_KeepsHeadersOwnedByTheLibrary()
+    {
+        using var client = new HttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "library-token");
+        client.DefaultRequestHeaders.Accept.Add(new("application/x-www-form-urlencoded"));
+
+        client.ApplyDefaultRequestHeaders(new Dictionary<string, string>
+        {
+            ["Authorization"] = "Bearer caller-token",
+            ["Accept"] = "application/json",
+            [HeaderName] = HeaderValue
+        });
+
+        client.ShouldSatisfyAllConditions(
+            () => GetHeaderValues(client, "Authorization").ShouldBe(["Bearer library-token"]),
+            () => GetHeaderValues(client, "Accept").ShouldBe(["application/x-www-form-urlencoded"]),
+            () => GetHeaderValues(client, HeaderName).ShouldBe([HeaderValue]));
+    }
+
+    /// <summary>
+    /// Verifies that applying headers twice replaces instead of appends, so the header is present exactly once
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_AppliedTwice_KeepsHeaderExactlyOnce()
+    {
+        using var client = new HttpClient();
+        var headers = new Dictionary<string, string> { [HeaderName] = HeaderValue };
+
+        client.ApplyDefaultRequestHeaders(headers);
+        client.ApplyDefaultRequestHeaders(headers);
+
+        GetHeaderValues(client, HeaderName).ShouldBe([HeaderValue]);
+    }
+
+    /// <summary>
+    /// Verifies that re-applying with a changed value replaces the previous value
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_ReApplied_ReplacesPreviousValue()
+    {
+        using var client = new HttpClient();
+
+        client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [HeaderName] = "first" });
+        client.ApplyDefaultRequestHeaders(new Dictionary<string, string> { [HeaderName] = "second" });
+
+        GetHeaderValues(client, HeaderName).ShouldBe(["second"]);
+    }
+
+    /// <summary>
+    /// Verifies that an invalid entry does not prevent the remaining valid entries from being applied
+    /// </summary>
+    [Test]
+    public void ApplyDefaultRequestHeaders_WithMixedEntries_AppliesOnlyValidOnes()
+    {
+        using var client = new HttpClient();
+
+        client.ApplyDefaultRequestHeaders(new Dictionary<string, string>
+        {
+            ["X Invalid Name"] = "value",
+            ["X-Invalid-Value"] = "value\r\ninjected",
+            ["Authorization"] = "Bearer caller-token",
+            [HeaderName] = HeaderValue
+        });
+
+        client.ShouldSatisfyAllConditions(
+            () => GetHeaderValues(client, HeaderName).ShouldBe([HeaderValue]),
+            () => client.DefaultRequestHeaders.Count().ShouldBe(1));
+    }
+
+    /// <summary>
+    /// Get all values of the given header, or an empty array if the header is not set.
+    /// </summary>
+    /// <param name="client">The client to read the header from.</param>
+    /// <param name="name">The header name to read.</param>
+    /// <returns>All values of the given header.</returns>
+    private static string[] GetHeaderValues(HttpClient client, string name)
+    {
+        return client.DefaultRequestHeaders.TryGetValues(name, out var values) ? values.ToArray() : [];
+    }
+}

--- a/tests/PingenApiNet.UnitTests/Tests/Services/PingenHttpClientsTests.cs
+++ b/tests/PingenApiNet.UnitTests/Tests/Services/PingenHttpClientsTests.cs
@@ -1,0 +1,160 @@
+namespace PingenApiNet.UnitTests.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="PingenHttpClients"/>
+/// </summary>
+public class PingenHttpClientsTests
+{
+    private const string HeaderName = "X-Amanda-Client";
+
+    private const string HeaderValue = "AMANDA.discountfit/2f3a9c1 (Backend; env=int)";
+
+    /// <summary>
+    /// Verifies that the configured default request headers are applied to the identity and the API http client
+    /// </summary>
+    [Test]
+    public void Create_WithDefaultRequestHeaders_AppliesThemToIdentityAndApiClients()
+    {
+        var httpClients = PingenHttpClients.Create(BuildConfiguration(new Dictionary<string, string> { [HeaderName] = HeaderValue }));
+
+        using (httpClients.Identity)
+        using (httpClients.Api)
+        using (httpClients.External)
+        {
+            httpClients.ShouldSatisfyAllConditions(
+                () => GetHeaderValues(httpClients.Identity, HeaderName).ShouldBe([HeaderValue]),
+                () => GetHeaderValues(httpClients.Api, HeaderName).ShouldBe([HeaderValue]));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the configured default request headers are NOT applied to the external http client. That client
+    /// targets pre signed third party storage URLs, which must not receive any pre-configured header (see ADR-004).
+    /// </summary>
+    [Test]
+    public void Create_WithDefaultRequestHeaders_DoesNotApplyToExternalClient()
+    {
+        var httpClients = PingenHttpClients.Create(BuildConfiguration(new Dictionary<string, string> { [HeaderName] = HeaderValue }));
+
+        using (httpClients.Identity)
+        using (httpClients.Api)
+        using (httpClients.External)
+        {
+            httpClients.External.DefaultRequestHeaders.ShouldBeEmpty();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the default request headers are applied after the headers configured by this library,
+    /// without dropping them
+    /// </summary>
+    [Test]
+    public void Create_WithDefaultRequestHeaders_KeepsAcceptHeaderOnIdentityClient()
+    {
+        var httpClients = PingenHttpClients.Create(BuildConfiguration(new Dictionary<string, string> { [HeaderName] = HeaderValue }));
+
+        using (httpClients.Identity)
+        using (httpClients.Api)
+        using (httpClients.External)
+        {
+            httpClients.Identity.DefaultRequestHeaders.Accept.ShouldHaveSingleItem()
+                .MediaType.ShouldBe("application/x-www-form-urlencoded");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that reserved header names are silently skipped, so they can never duplicate or overwrite a header
+    /// owned by this library
+    /// </summary>
+    [TestCase("Authorization")]
+    [TestCase("Accept")]
+    [TestCase("Host")]
+    [TestCase("Idempotency-Key")]
+    public void Create_WithReservedDefaultRequestHeader_SkipsIt(string name)
+    {
+        var httpClients = PingenHttpClients.Create(BuildConfiguration(new Dictionary<string, string> { [name] = "caller-value" }));
+
+        using (httpClients.Identity)
+        using (httpClients.Api)
+        using (httpClients.External)
+        {
+            GetHeaderValues(httpClients.Api, name).ShouldBeEmpty();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that invalid default request headers are skipped instead of failing the client construction
+    /// </summary>
+    [Test]
+    public void Create_WithInvalidDefaultRequestHeaders_SkipsThemWithoutThrowing()
+    {
+        IPingenConfiguration configuration = BuildConfiguration(new Dictionary<string, string>
+        {
+            ["X Invalid Name"] = "value",
+            ["X-Invalid-Value"] = "value\r\nX-Injected: evil",
+            ["X-Blank-Value"] = " ",
+            [HeaderName] = HeaderValue
+        });
+
+        PingenHttpClients httpClients = null!;
+
+        Should.NotThrow(() => httpClients = PingenHttpClients.Create(configuration));
+
+        using (httpClients.Identity)
+        using (httpClients.Api)
+        using (httpClients.External)
+        {
+            httpClients.ShouldSatisfyAllConditions(
+                () => GetHeaderValues(httpClients.Api, HeaderName).ShouldBe([HeaderValue]),
+                () => httpClients.Api.DefaultRequestHeaders.Count().ShouldBe(1));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the http clients carry no additional headers when none are configured
+    /// </summary>
+    [Test]
+    public void Create_WithoutDefaultRequestHeaders_AppliesNoAdditionalHeaders()
+    {
+        var httpClients = PingenHttpClients.Create(BuildConfiguration());
+
+        using (httpClients.Identity)
+        using (httpClients.Api)
+        using (httpClients.External)
+        {
+            httpClients.ShouldSatisfyAllConditions(
+                () => httpClients.Identity.DefaultRequestHeaders.ShouldHaveSingleItem().Key.ShouldBe("Accept"),
+                () => httpClients.Api.DefaultRequestHeaders.ShouldBeEmpty(),
+                () => httpClients.External.DefaultRequestHeaders.ShouldBeEmpty());
+        }
+    }
+
+    /// <summary>
+    /// Build a configuration for the tests, optionally with additional default request headers.
+    /// </summary>
+    /// <param name="defaultRequestHeaders">Optional, additional static default request headers.</param>
+    /// <returns>The configuration to create the http clients from.</returns>
+    private static PingenConfiguration BuildConfiguration(IReadOnlyDictionary<string, string>? defaultRequestHeaders = null)
+    {
+        return new PingenConfiguration
+        {
+            BaseUri = "https://api.example.com/",
+            IdentityUri = "https://identity.example.com/",
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            DefaultOrganisationId = "test-org-id",
+            DefaultRequestHeaders = defaultRequestHeaders
+        };
+    }
+
+    /// <summary>
+    /// Get all values of the given header, or an empty array if the header is not set.
+    /// </summary>
+    /// <param name="client">The client to read the header from.</param>
+    /// <param name="name">The header name to read.</param>
+    /// <returns>All values of the given header.</returns>
+    private static string[] GetHeaderValues(HttpClient client, string name)
+    {
+        return client.DefaultRequestHeaders.TryGetValues(name, out var values) ? values.ToArray() : [];
+    }
+}


### PR DESCRIPTION
## What and why

Consumers need to stamp a static caller-identification header (in AMANDA's case `X-Amanda-Client: AMANDA.discountfit/<sha> (Backend; env=int)`) on every outbound request to Pingen, so a partner's access log and our own telemetry name the same host/env/build. Today the only way to get a header onto the library's clients is to construct all three `HttpClient` instances yourself and use the caller-supplied `PingenHttpClients` constructor — which means giving up `IHttpClientFactory` and re-implementing the base addresses, the accept header and `AllowAutoRedirect = false`.

This adds one optional configuration property and one public extension method. The same surface is landing in the sibling `*ApiNet` libraries, so the shape is deliberately uniform and not tailored to this repo.

## New public surface (additive only)

```csharp
// src/PingenApiNet/Interfaces/IPingenConfiguration.cs — DEFAULT INTERFACE MEMBER
public IReadOnlyDictionary<string, string>? DefaultRequestHeaders => null;

// src/PingenApiNet/Services/PingenConfiguration.cs (sealed record)
public IReadOnlyDictionary<string, string>? DefaultRequestHeaders { get; set; }

// src/PingenApiNet/Configuration/HttpClientExtension.cs (new file, core package)
namespace PingenApiNet.Configuration;

public static class HttpClientExtension
{
    public static HttpClient ApplyDefaultRequestHeaders(this HttpClient client, IReadOnlyDictionary<string, string>? headers);
}
```

The extension is **public**, not internal, so it also closes the "caller-supplied `HttpClient` gets nothing" gap on the existing `PingenHttpClients(HttpClient, HttpClient, HttpClient)` primary constructor.

### Semantics (documented in the XML doc, pinned by tests)

- Applied **once per `HttpClient`**, onto `DefaultRequestHeaders`. Static values only — per-request values belong on the `HttpRequestMessage`.
- Applied **after** the headers this library sets itself, via `Remove(name)` then `TryAddWithoutValidation(name, value)`, so re-applying replaces instead of appends.
- Reserved names are **silently skipped**, case-insensitive: `Authorization`, `Accept`, `Host` and `Idempotency-Key`. Load-bearing: the header collections **append** on a duplicate name instead of throwing, so an unguarded caller entry would transmit two values and break authentication or idempotency.
- **Never throws.** `null`/empty is a no-op; a blank name or value, a name containing an invalid header-name token character (RFC 9110: ALPHA / DIGIT / ``!#$%&'*+-.^_`|~``), or a value containing a control character (< 0x20 or 0x7F, notably CR/LF) is skipped. Not cosmetic: `TryAddWithoutValidation` accepts a CRLF-bearing value and `SocketsHttpHandler` then throws at **send** time — a diagnostic header must never be able to fail a real letter dispatch.

## The `Pingen.Files` exclusion — the important part

The headers are applied at both construction sites to **`Pingen.Identity` and `Pingen.Api` only**:

| Client | Site | Header |
|---|---|---|
| Identity | `PingenServiceCollection.cs`, `PingenHttpClients.Create` | yes |
| Api | `PingenServiceCollection.cs`, `PingenHttpClients.Create` | yes |
| **Files / External** | `services.AddHttpClient(PingenHttpClients.Names.Files)`, `new HttpClient()` | **no — untouched** |

That client PUTs/GETs Pingen-issued **pre-signed third-party storage URLs** (`FilesService.UploadFile`, `LetterService.DownloadFileContent` via `SendExternalRequestAsync`), not Pingen's own API. [ADR-004](doc/architecture/decisions/004-three-http-clients.md) and the `IPingenConnectionHandler.SendExternalRequestAsync` XML doc both require it to carry **no pre-configured headers** — an extra header risks a signature rejection by the storage provider. Both registration sites now carry an explicit comment saying so, and ADR-004 has been extended with the rationale, so nobody later "fixes the inconsistency".

The exclusion is pinned by three tests, all verified to **fail** when it is removed (temporarily applied the headers to the files/external client and re-ran):

- `AddPingenServices_WithDefaultRequestHeaders_DoesNotApplyToFilesClient` (DI)
- `Create_WithDefaultRequestHeaders_DoesNotApplyToExternalClient` (standalone)
- `ExternalFileUpload_ShouldNotSendConfiguredDefaultRequestHeader` (wire-level, WireMock)

`ConfigurePrimaryHttpMessageHandler` on the API client is untouched — `AllowAutoRedirect = false` stays load-bearing (`GetApiResult` treats `302` as success for the file-location endpoint).

## Why this is non-breaking

- The interface member is a **default interface member**, so external implementers of the public `IPingenConfiguration` are not source-broken.
- The record property is **not `required`**, so existing object initialisers keep compiling.
- **No existing public signature changes.** Both `AddPingenServices` overloads keep their exact shape, including the five-string one; it simply passes no headers.
- No optional parameter was added to an already-published public method (that would be binary-breaking for un-recompiled callers).
- No target-framework, dependency or CI change.

## Version

Intended release: **1.4.0** (additive/minor). Note this repo derives the package version purely from the git tag (`build/GetBuildVersion.psm1` reads `$GITHUB_REF`, CI passes `-p:Version`/`-p:PackageVersion`) — there is **no `<Version>` in any csproj** to bump, so no version edit is included here. Tagging/publishing is left to the maintainer.

## Tests

`dotnet build` clean (0 warnings, 0 errors, Debug + Release). `dotnet test` green:

| Project | Before | After |
|---|---|---|
| `PingenApiNet.UnitTests` | 719 | **770** (+51) |
| `PingenApiNet.Tests.Integration` | 162 | **166** (+4) |

- `tests/PingenApiNet.UnitTests/Tests/Configuration/HttpClientExtensionTests.cs` (new) — full contract suite: null / empty / valid / blank name / blank value / CR / LF / CRLF / DEL / NUL in value / invalid name token chars / non-ASCII name / all four reserved names in both casings / applied twice → present exactly once / re-apply replaces / mixed valid+invalid / returns the same client for chaining / library-owned `Authorization` + `Accept` untouched.
- `tests/PingenApiNet.UnitTests/Tests/AspNetCore/PingenServiceCollectionTests.cs` (extended) — the same contract through the DI surface, plus the files-client exclusion, `Accept` still present on the identity client, one value per created client, and "no additional headers when none are configured".
- `tests/PingenApiNet.UnitTests/Tests/Services/PingenHttpClientsTests.cs` (new) — the standalone `PingenHttpClients.Create` mirror, incl. the external-client exclusion.
- `tests/PingenApiNet.Tests.Integration/Tests/CrossCutting/DefaultRequestHeadersTests.cs` (new) — wire-level: the header reaches the Pingen API request and the identity/token request, does **not** reach the external file upload, and a caller-configured `Idempotency-Key` never displaces the one the library sends itself. `IntegrationTestBase` gained a `protected virtual DefaultRequestHeaders` hook and now mirrors the two library construction sites.

Docs updated: README (DI section), ADR-004 (new "Caller-supplied default request headers" subsection), AGENTS.md (three-clients convention + test inventory).
